### PR TITLE
Add combineActionReducers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # `brookjs`
 
-**Note: Early alpha. Expect breaking changes before version 0.1.0. See [semver][#Semver] policy below.**
+**Note: Early alpha. Expect breaking changes before version 0.1.0. See [semver](#semver) policy below.**
 
 `brookjs` is framework for building functional, reactive JavaScript applications. The core of the library is built on [`kefir`][kefir] for Observables and [`ramda`][ramda] as a utility library. Everything else is designed to be as flexible as possible, allowing you to pick and choose which modules to use while designing them to work together seamlessly with common patterns. While not required, [`redux`][redux] is recommended for data management, with its `Symbol.observable` interop and significant community.
 
@@ -30,6 +30,7 @@ Be sure the grab the latest commit sha from GitHub.
 
 # Modules
 
+* [combineActionReducers][] - Action-based state transitions.
 * [component][] - Declarative UI lifecycle management.
 * [observeDelta][] - Redux enhancer for streaming side effects.
 * [util][] - Utility functions for standard patterns.
@@ -41,6 +42,7 @@ Be sure the grab the latest commit sha from GitHub.
   [kefir]: http://rpominov.github.io/kefir/
   [ramda]: http://ramdajs.com/
   [redux]: http://redux.js.org/
+  [combineActionReducers]: combineActionReducers/README.md
   [component]: component/README.md
   [observeDelta]: observeDelta/README.md
   [util]: util/README.md

--- a/combineActionReducers/README.md
+++ b/combineActionReducers/README.md
@@ -1,0 +1,106 @@
+# `brookjs-combineActionReducers`
+
+`combineActionReducers` is an alternate method for structuring your reducers. Using `Redux`'s default `combineReducers`, I ran into two issues:
+
+1. By sectioning off state by key, an individual reducer loses access to the rest of the state. If a piece of state needs to be set conditionally based on another piece of state, the reducer cannot read it.
+
+    In my case, this was the result of an anti-pattern; the state wasn't normalized, so all of the UI logic lived in the reducer. This was resolved by exposing `modifyState` in the `bootrap` module, allowing us to modify the UI state stream and map the application state to the UI props, much like `mapStateToProps` in `react-redux`.
+
+    `combineActionReducers` allows you to centralize the logic for a given action, functioning as a transition step between a denormalized state and a normalized one. Seeing how an action modifies the state enables
+
+2. Outside of being a transition tool, `combineActionReducers` allows you to view the state as a set of transitions, rather than a series of states. While view makes sense from a dev tools perspective, the development process, especially in brookjs, tends to be action oriented. Components are defined by the actions they emit and how they map their children's actions, and delta sources respond to and emit their own events.
+
+    If there's a bug in your application, you start at the lowest-level component and ensure it emits the action you expect. You then go to the state and see if it changes the way it's supposed to. If that's not the problem, you look at the UI props (now using `modifyState`) to ensure that's what you expect. Finally, you ensure the components render the way their supposed to, given that state.
+
+    Overall, the debugging flow through the application is very clear, and the first half of that process is all action oriented. If the bug needs to be fixed in multiple parts of the state, `combineReducers` would require you to update multiple functions/sub-reducers. However, in my experience, you're much more likely to need to modify how the state changes in response to that action than needing to modify how the piece of substate changes in response to multiple actions at once.
+
+Obviously, this is very much limited by my total experience with both Redux and `brookjs` so far, so this is a proof of concept to see if this approach makes sense for structuring a larger reducer. Even if this isn't the ideal pattern for building your entire reducer, you don't need to switch from one to the other, but both `combineReducers` and `combineActionReducers` can be used together. This is explained below.
+
+# How to Use
+
+Assuming you have `brookjs` installed (if not, see the main [README.md][main-readme]), you can destructure it off the main export:
+
+```js
+import { combineActionReducers } from 'brookjs';
+import { ACTION_TYPE } from '../actions';
+import actionTypeReducer from './actionTypeReducer';
+
+export default combineActionReducers([
+    [ACTION_TYPE, actionTypeReducer]
+]);
+```
+
+`combineActionReducers` accepts an array of tuples, with the first value equaling the `action.type` value that maps to the reducer. The second value is the reducer function to call when the `action.type` maps to the current action. This syntax is inspired by ramda's [`cond`][cond].
+
+An action reducer is the same type as the reducer functions passed to `combineReducers`, so it should feel familiar. The main difference is the function gets broken up by action. In redux, you'd do something like this:
+
+ ```js
+ export default reducer(state, { type, payload = {} }) {
+     const { value } = payload;
+
+     switch (type) {
+         case ACTION_TYPE:
+            return Object.assign({}, state, { value });
+        case OTHER_ACTION_TYPE:
+           return Object.assign({}, state, { value: !value });
+        default:
+            return state;
+     }
+ }
+ ```
+
+ Adding `combineActionReducers`, we can simplify this thusly:
+
+ ```js
+import { combineActionReducers } from 'brookjs';
+
+const actionTypeReducer = (state, { payload }) =>
+    Object.assign({}, state, { value: payload.value });
+
+const otherActionTypeReducer = (state, { payload }) =>
+    Object.assign({}, state, { value: !payload.value });
+
+ export default combineActionReducers([
+     [ACTION_TYPE, actionTypeReducer],
+     [OTHER_ACTION_TYPE, otherActionTypeReducer]
+ ]);
+ ```
+
+ There are two advantages to structuring your reducers like this. First, the default case is handled for you, rather than needing to remember to return the current state by default. Secondly, each individual `actionReducer` is smaller, which makes it both easier to test and easier to reason about.
+
+## Using with `combineReducers`
+
+When using both `combineReducers` and `combineActionReducers`, use `combineReducers` to build up all of your branch reducers. At the point where you would normally write a long switch statement, swap out the reducer with `combineActionReducers`.
+
+```js
+import { combineReducers } from 'redux';
+import { combineActionReducers } from 'brookjs';
+
+// Normally, you'd import these so the names aren't so dopey.
+const valueActionTypeReducer =
+    (value, { payload }) => payload.value + value;
+
+const valueOtherActionTypeReducer =
+    (value, { payload }) => payload.value / 2 - value;
+
+const value = combineActionReducers([
+    [ACTION_TYPE, actionTypeReducer],
+    [OTHER_ACTION_TYPE, otherActionTypeReducer]
+]);
+
+const disabledActionTypeReducer =
+    (disabled, { payload }) => !disabled && payload.value > 50;
+
+const valueOtherActionTypeReducer =
+    (disabled, { payload }) => disabled && payload.value < 10;
+
+const disabled = combineActionReducers([
+    [ACTION_TYPE, actionTypeReducer],
+    [OTHER_ACTION_TYPE, otherActionTypeReducer]
+]);
+
+export default combineReducers({ value, disabled });
+```
+
+  [main-readme]: ../README.md
+  [cond]: http://ramdajs.com/0.22.1/docs/#cond

--- a/combineActionReducers/README.md
+++ b/combineActionReducers/README.md
@@ -1,24 +1,10 @@
 # `brookjs-combineActionReducers`
 
-`combineActionReducers` is an alternate method for structuring your reducers. Using `Redux`'s default `combineReducers`, I ran into two issues:
-
-1. By sectioning off state by key, an individual reducer loses access to the rest of the state. If a piece of state needs to be set conditionally based on another piece of state, the reducer cannot read it.
-
-    In my case, this was the result of an anti-pattern; the state wasn't normalized, so all of the UI logic lived in the reducer. This was resolved by exposing `modifyState` in the `bootrap` module, allowing us to modify the UI state stream and map the application state to the UI props, much like `mapStateToProps` in `react-redux`.
-
-    `combineActionReducers` allows you to centralize the logic for a given action, functioning as a transition step between a denormalized state and a normalized one. Seeing how an action modifies the state enables
-
-2. Outside of being a transition tool, `combineActionReducers` allows you to view the state as a set of transitions, rather than a series of states. While view makes sense from a dev tools perspective, the development process, especially in brookjs, tends to be action oriented. Components are defined by the actions they emit and how they map their children's actions, and delta sources respond to and emit their own events.
-
-    If there's a bug in your application, you start at the lowest-level component and ensure it emits the action you expect. You then go to the state and see if it changes the way it's supposed to. If that's not the problem, you look at the UI props (now using `modifyState`) to ensure that's what you expect. Finally, you ensure the components render the way their supposed to, given that state.
-
-    Overall, the debugging flow through the application is very clear, and the first half of that process is all action oriented. If the bug needs to be fixed in multiple parts of the state, `combineReducers` would require you to update multiple functions/sub-reducers. However, in my experience, you're much more likely to need to modify how the state changes in response to that action than needing to modify how the piece of substate changes in response to multiple actions at once.
-
-Obviously, this is very much limited by my total experience with both Redux and `brookjs` so far, so this is a proof of concept to see if this approach makes sense for structuring a larger reducer. Even if this isn't the ideal pattern for building your entire reducer, you don't need to switch from one to the other, but both `combineReducers` and `combineActionReducers` can be used together. This is explained below.
+`combineActionReducers` is an alternate method for structuring your reducers. Can be used with Redux's `combineReducers` to eliminate long switch statements and encourage extracting each case into a testable function.
 
 # How to Use
 
-Assuming you have `brookjs` installed (if not, see the main [README.md][main-readme]), you can destructure it off the main export:
+Assuming you have `brookjs` installed, you can destructure it off the main export:
 
 ```js
 import { combineActionReducers } from 'brookjs';
@@ -30,9 +16,9 @@ export default combineActionReducers([
 ]);
 ```
 
-`combineActionReducers` accepts an array of tuples, with the first value equaling the `action.type` value that maps to the reducer. The second value is the reducer function to call when the `action.type` maps to the current action. This syntax is inspired by ramda's [`cond`][cond].
+`combineActionReducers` accepts an array of tuples, with the first value as the `action.type` for the reducer and the second value as the reducer function to call for that `action.type`. This syntax is inspired by ramda's [`cond`][cond].
 
-An action reducer is the same type as the reducer functions passed to `combineReducers`, so it should feel familiar. The main difference is the function gets broken up by action. In redux, you'd do something like this:
+An action reducer looks just like the reducer functions for `combineReducers`. The main difference is the function gets broken up by action. In redux, you'd do something like this:
 
  ```js
  export default reducer(state, { type, payload = {} }) {
@@ -49,7 +35,7 @@ An action reducer is the same type as the reducer functions passed to `combineRe
  }
  ```
 
- Adding `combineActionReducers`, we can simplify this thusly:
+ Adding `combineActionReducers`, we can simplify thusly:
 
  ```js
 import { combineActionReducers } from 'brookjs';
@@ -66,7 +52,7 @@ const otherActionTypeReducer = (state, { payload }) =>
  ]);
  ```
 
- There are two advantages to structuring your reducers like this. First, the default case is handled for you, rather than needing to remember to return the current state by default. Secondly, each individual `actionReducer` is smaller, which makes it both easier to test and easier to reason about.
+ There are two advantages to structuring your reducers like this. First, the default case is handled for you, rather than needing to remember to return the current state. Secondly, each individual `actionReducer` is smaller, which makes it both easier to test and easier to reason about.
 
 ## Using with `combineReducers`
 
@@ -91,7 +77,7 @@ const value = combineActionReducers([
 const disabledActionTypeReducer =
     (disabled, { payload }) => !disabled && payload.value > 50;
 
-const valueOtherActionTypeReducer =
+const disabledOtherActionTypeReducer =
     (disabled, { payload }) => disabled && payload.value < 10;
 
 const disabled = combineActionReducers([
@@ -101,6 +87,40 @@ const disabled = combineActionReducers([
 
 export default combineReducers({ value, disabled });
 ```
+
+# Alternate Approaches
+
+## Action Oriented Reducer
+
+Instead of an easy-to-read way of defining long switch statements in subreducers, `combineActionCreators` can be used to structure the entire reducer. Doing so allows you to view the state as a set of transitions, rather than a series of values. While this view makes sense from a dev tools perspective, the development process, especially in brookjs, tends to be action oriented. Components are defined by the actions they emit and how they map their children's actions, and delta sources respond to and emit their own events.
+
+If there's a bug in your application, you start at the lowest-level component and ensure it emits the action you expect. You then go to the state and see if it changes the way it's supposed to. If that's not the problem, you look at the UI props (now using `modifyState`) to ensure that's what you expect. Finally, you ensure the components render the way their supposed to, given that state.
+
+Overall, the debugging flow through the application becomes very clear, and the first half of that process is all action oriented. If the bug needs to be fixed in multiple parts of the state, `combineReducers` would require you to update multiple functions/sub-reducers, whereas most bugs occur in response to an action.
+
+## Denormalized State Escape Hatch
+
+`combineActionReducers` can also help you normalize a state tree. If two pieces of state depend on each other, but don't exist in the same branch of the state tree, that value may be better off fetched from a selector function.`
+
+Cross-key state dependency is a code smell; if one part of your state is depending upon another, the state isn't normalized, and properties that are merely the result of computing other properties don't belong in your state.
+
+`combineActionReducers` allows you to centralize the logic for a given action with access to the whole state. Wrapping the reducer like this:
+
+```js
+import { combineActionReducer } from 'brookjs';
+import combinedReducer from './reducer';
+
+const actionReducer = combineActionReducer([
+    [ACTION_TYPE, actionTypeReducer]
+])
+
+export default function reducer(state, action) {
+    state = combinedReducer(state, action);
+    return actionReducer(state, action);
+}
+```
+
+`actionTypeReducer` will be passed the entire state, allowing the codependent logic to be centralized. The computed property can then be extracted into a selector function, and reused when mapping state to props.
 
   [main-readme]: ../README.md
   [cond]: http://ramdajs.com/0.22.1/docs/#cond

--- a/combineActionReducers/__tests__/combineActionReducers.spec.js
+++ b/combineActionReducers/__tests__/combineActionReducers.spec.js
@@ -1,0 +1,43 @@
+/* eslint-env mocha */
+import R from 'ramda';
+
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+import combineActionReducers from '../';
+
+chai.use(sinonChai);
+
+const TYPE = 'TYPE';
+
+describe('combineActionReducers', () => {
+    let reducer, spy;
+    const initial = { value: 'initial value' };
+    const returns = { value: 'returned value' };
+
+    beforeEach(() => {
+        spy = sinon.spy(R.always(returns));
+        reducer = combineActionReducers([
+            [TYPE, spy]
+        ]);
+    });
+
+    it('should return a function', () => {
+        expect(reducer).to.be.a('function');
+    });
+
+    it('should return initial when action.type does not match', () => {
+        const result = reducer(initial, { type: 'NOT_TYPE' });
+
+        expect(spy).to.have.callCount(0);
+        expect(result).to.equal(initial);
+    });
+
+    it('should return new when action.type does match', () => {
+        const result = reducer({}, { type: TYPE });
+
+        expect(spy).to.have.callCount(1);
+        expect(result).to.equal(returns);
+    });
+});

--- a/combineActionReducers/index.js
+++ b/combineActionReducers/index.js
@@ -1,0 +1,11 @@
+import R from 'ramda';
+
+export default R.reduce((func, [type, reducer]) => {
+    return (state, action) => {
+        if (action.type === type) {
+            state = reducer(state, action);
+        }
+
+        return func(state, action);
+    };
+}, R.identity);

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
+import combineActionReducers from './combineActionReducers';
 import component from './component';
 import observeDelta from './observeDelta';
 import util from './util';
 import bootstrap, { BROOKJS_INIT } from './bootstrap';
 
-const brook = { bootstrap, component, observeDelta, util, BROOKJS_INIT };
+const brook = { bootstrap, combineActionReducers, component, observeDelta, util, BROOKJS_INIT };
 
-export { brook, bootstrap, component, observeDelta, util, BROOKJS_INIT };
+export { brook, bootstrap, combineActionReducers, component, observeDelta, util, BROOKJS_INIT };
 
 export default brook;


### PR DESCRIPTION
Provides a function for replacing long switch statements with a simplified
mapping of action types to reducer function, combining those tuples to
form an easy to understand reducer function.