### PR TITLE
Remove Array.from

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,7 +1,6 @@
 {
   "plugins": [
     "ramda",
-    "transform-array-from",
     "transform-object-assign"
   ],
   "env": {

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 * `WeakMap`
 * `Object.assign`
-* `Array.from`
 * `MutationObserver`
 
 `Object.assign` & `Array.from` are transpiled with a pair of babel plugins, so polyfills for `WeakMap` & `MutationObserver` are required.

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "babel-loader": "^6.2.4",
     "babel-plugin-istanbul": "^2.0.0",
     "babel-plugin-ramda": "^1.1.3",
-    "babel-plugin-transform-array-from": "^1.0.0",
     "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.13.2",
     "babel-register": "^6.9.0",
@@ -68,7 +67,6 @@
     "webpack-merge": "^0.20.0"
   },
   "dependencies": {
-    "array-from": "^2.1.1",
     "kefir": "^3.3.0",
     "morphdom": "^2.0.1",
     "ramda": "^0.22.1",

--- a/src/children/index.js
+++ b/src/children/index.js
@@ -86,7 +86,7 @@ export default function children(config) {
              *
              * Filters out children that are under other containers.
              */
-            const els$ = constant(Array.from(element.querySelectorAll(`[${containerAttribute(container)}]`)))
+            const els$ = constant(element.querySelectorAll(`[${containerAttribute(container)}]`))
                 .flatten()
                 .filter(R.pipe(R.prop('parentNode'), getContainerNode, R.equals(element)))
                 .map(createInstanceWithProps)

--- a/src/children/mutations.js
+++ b/src/children/mutations.js
@@ -1,3 +1,4 @@
+import R from 'ramda';
 import { CONTAINER_ATTRIBUTE, KEY_ATTRIBUTE } from '../constants';
 import { stream } from 'kefir';
 import { nodeAdded, nodeRemoved } from './actions';
@@ -11,7 +12,6 @@ import { getContainerNode } from './util';
  */
 function isRelevantNode(node) {
     return !!(node.hasAttribute && node.hasAttribute(CONTAINER_ATTRIBUTE));
-
 }
 
 /**
@@ -25,7 +25,7 @@ export default stream(emitter => {
     const observer = new MutationObserver(mutations => {
         mutations.forEach(mutation => {
             // @todo this logic could be much better
-            Array.from(mutation.addedNodes).forEach(node => {
+            R.forEach(node => {
                 if (!node.querySelectorAll) {
                     return;
                 }
@@ -33,7 +33,7 @@ export default stream(emitter => {
                 if (isRelevantNode(node)) {
                     emitter.value(nodeAdded(mutation.target, node));
                 } else {
-                    Array.from(node.querySelectorAll(`[${CONTAINER_ATTRIBUTE}]`)).forEach(container => {
+                    R.forEach(container => {
                         let parent = container.parentNode;
 
                         while (parent && parent !== node && !isRelevantNode(parent)) {
@@ -43,11 +43,11 @@ export default stream(emitter => {
                         if (parent && parent === node) {
                             emitter.value(nodeAdded(mutation.target, container));
                         }
-                    });
+                    }, node.querySelectorAll(`[${CONTAINER_ATTRIBUTE}]`));
                 }
-            });
+            }, mutation.addedNodes);
 
-            Array.from(mutation.removedNodes).forEach(node => {
+            R.forEach(node => {
                 if (!node.querySelectorAll) {
                     return;
                 }
@@ -55,7 +55,7 @@ export default stream(emitter => {
                 if (isRelevantNode(node)) {
                     emitter.value(nodeRemoved(mutation.target, node));
                 } else {
-                    Array.from(node.querySelectorAll(`[${CONTAINER_ATTRIBUTE}]`)).forEach(container => {
+                    R.forEach(container => {
                         let parent = container.parentNode;
 
                         while (parent && parent !== node && !isRelevantNode(parent)) {
@@ -65,9 +65,9 @@ export default stream(emitter => {
                         if (parent && parent === node) {
                             emitter.value(nodeRemoved(mutation.target, container));
                         }
-                    });
+                    }, node.querySelectorAll(`[${CONTAINER_ATTRIBUTE}]`));
                 }
-            });
+            }, mutation.removedNodes);
         });
     });
 


### PR DESCRIPTION
`flatten` doesn't need it to be an array, and we can repace `forEach` w/
`R.forEach` so we don't need to use `Array.from`.

Fixes #11.