### PR TITLE
Refactor render process

### DIFF
--- a/docs/source/_data/nav.yml
+++ b/docs/source/_data/nav.yml
@@ -18,16 +18,16 @@
     title: Using a Template to <code>render</code> a Component
   - id: managing-children-components-in-a-component
     title: Managing <code>children</code> Components
-- title: Building a <code>brookjs</code> Application (Coming soon!)
+- title: Building a <code>brookjs</code> Application
   items:
-  - id: building-the-reducer-with-combineActionReducers
-    title: Building the Reducer with <code>combineActionReducers</code>
   - id: handling-side-effects-with-observeDelta
     title: Handling Side Effects with <code>observeDelta</code>
+  - id: building-the-reducer-with-combineActionReducers
+    title: Building the Reducer with <code>combineActionReducers</code> (Coming soon!)
   - id: mounting-the-root-component-with-unnamedModule
-    title: Mounting the Root Component with <code>unnamedModule</code>
+    title: Mounting the Root Component with <code>unnamedModule</code> (Coming soon!)
   - id: starting-the-application-with-run
-    title: Starting the Application with <code>run</code>
+    title: Starting the Application with <code>run</code> (Coming soon!)
 - title: Advanced Component Techniques (Coming soon!)
   items:
   - id: custom-animations-and-reconciliation-with-renderFromHTML

--- a/docs/source/children.md
+++ b/docs/source/children.md
@@ -55,12 +55,12 @@ export default children({
         // factory function for child taking el & props$
         factory: kid,
         // passed parents' `props$` stream & child key.
-        // return value is passed to child factory.
-        // see below for key docuentation.
+        // return value is passed to child onMount.
+        // see below for key documentation.
         modifyChildProps: (props$, key) => props$.map(props => props.children[key]),
         // passed each child instance to modify child stream
         // return value is plugged into combined string (hence `preplug`)
-        preplug: kid$ => kid$.map(mapActionTo(CHILD_ACTION, PARENT_ACTION))
+        preplug: (kid$, key) => kid$.map(mapActionTo(CHILD_ACTION, PARENT_ACTION)).map(action => Object.assign({}, action, { meta: { key } }))
     }
 });
 ```
@@ -100,4 +100,4 @@ The parent is then responsible for iterating over the props and rendering the ch
 </div>
 ```
 
-For each child, when it's mounted or added to the DOM, `modifyChildProps` is called with the parent's `props$` stream and the value of the child's key attribute. The returned stream should be of the child's props.
+For each child, when it's mounted or added to the DOM, `modifyChildProps` is called with the parent's `props$` stream and the value of the child's key attribute. The returned stream should be of the child's props. This is primarily useful to provide the correct props to the child's `onMount` function.

--- a/docs/source/component.md
+++ b/docs/source/component.md
@@ -83,7 +83,7 @@ _Note: **All functions must be curried.** `brookjs` relies on [`ramda`][ramda] f
 * `{Function}` combinator - Hook to combine streams before returning them from the factory. Merges the streams by default.
     * Paramters:
         * `{Object}` streams - Object containing a property for each component stream, including `events$`, `render$`, `children$`, and `onMount$`. Should return a new stream combining the provided events. Provides a hook to coordinate stream events, if necessary.
-* `{Function}` onMount - `onMount$` stream returning function. Called once, when the component is mounted, providing an entry point for any custom event or render logic.
+* `{Function}` onMount - `onMount$` stream returning function. Called once, when the component is mounted, providing an entry point for any custom events. `onMount` should avoid doing any direct DOM manipulation unless the component is blackboxed.
     * Parameters:
         * `{Element}` el - Componenent element.
         * `{Kefir.Observable}` props$ - Observable of props. Used to render children.

--- a/docs/source/handling-side-effects-with-observeDelta.md
+++ b/docs/source/handling-side-effects-with-observeDelta.md
@@ -3,4 +3,56 @@ id: handling-side-effects-with-observeDelta
 title: Handling Side Effects with <code>observeDelta</code>
 ---
 
-Coming soon!
+Once the view layer is up and running, the next step is to mount the view into the application. The view layer will be mounted into a "delta". A delta is a function that takes a stream of `actions$` and a stream of `state$` from Redux and returns a new stream of actions that get emitted into the store. This is bound into the store through the `observeDelta` middleware.
+
+`domDelta` is implemented as a function that returns a delta, and all userland deltas should be implemented this way. Mount the view into the middleware:
+
+```js
+import { observeDelta, domDelta } from 'brookjs';
+import component from './component';
+
+const el = doc => fromCallback(cb => {
+    cb(doc.getElementById('app'));
+});
+
+const selectProps = state$ => state$.map(state => ({
+    ...state,
+    isProps: true
+}));
+
+export default observeDelta(
+    domDelta({ el, component, selectProps })
+)
+```
+
+The `selectProps` function maps a stream of state$ values from the Redux store to a stream of props$ for the dom delta. The `observeDelta` middleware can now be mounted into the store:
+
+```js
+import { createStore, applyMiddleware } from 'redux';
+import deltaMiddleware from './delta';
+import reducer from './reducer';
+
+export default createStore(reducer, applyMiddleware(deltaMiddleware));
+```
+
+And the component will be called with the props$ returned from `selectProps`. The `el` can be either the element itself or a function that will be called with the document and should return a stream that emits the element. Because the `domDelta` won't be mounted until the `DOMContentLoaded` event has fired or the DOM has fully loaded, providing a stream allows the query process to be deferred until the DOM is ready.
+
+To handle custom side effects, create a custom delta. To do so, create a function that takes an options object and returns a function that takes a stream of `actions$` and `state$`. The returned function should return its own stream of `actions$` that will be piped into the store.
+
+Similar to [`redux-observable`][red-obs], the `actions$` stream has been enhanced with the `ofType` method, which filters the stream to only emit actions of the provided types. Multiple types can be provided.
+
+```js
+import Kefir from 'kefir';
+import { SUBMIT_FORM, formSubmitSuccess, formSubmitFail } from './actions';
+
+export default function ajaxDelta({ ajax }) {
+    return (actions$, state$) => actions$.ofType(SUBMIT_FORM)
+        .flatMap(action => ajax.post('/api', action.payload))
+        .map(formSubmitted)
+        .flatMapErrors(err => Kefir.constant(formSubmitFail(err)))
+}
+```
+
+Providing the ajax service through the `ajaxDelta` options object keeps the delta pure, making it easier to test that the delta functions as expected without having to mock the XMLHttpRequest object itself. The `ajax` service itself can then be isolated and tested against the mock object, reducing the amount of work done by each set of unit tests.
+
+  [red-obs]: https://redux-observable.js.org/docs/basics/Epics.html

--- a/docs/source/managing-children-components-in-a-component.md
+++ b/docs/source/managing-children-components-in-a-component.md
@@ -55,7 +55,10 @@ export default component({
             modifyChildProps: (props$, key) => props$.map(mapToChildProps),
             preplug: (child$, key) => child$.map(action => {
                 if (action.type === 'CLICK') {
-                    action = Object.assign({}, action, { type: 'SUBMIT_CLICK'});
+                    action = Object.assign({}, action, {
+                        type: 'SUBMIT_CLICK',
+                        meta: { key }
+                    });
                 }
 
                 return action;
@@ -67,6 +70,6 @@ export default component({
 
 ## A Note About the `data-brk-key` Attribute
 
-If a Component is going to be iterated over in a parent, the `data-brk-key` attribute is recommended for both performance and disambiguation reasons. If the child element doesn't have the attribute, the above two functions will be called with `null` as the key. The attribute is not required, but the `modifyChildProps` function otherwise has no way to modify the values emitted from child's `props$`. If there is only one instance of that child type, this isn't a problem, but multiple children need to be distinguished in order to provide the appropriate props.
+If a Component is going to be iterated over in a parent, the `data-brk-key` attribute is recommended for performance. If the child element doesn't have the attribute, the above two functions will be called with `null` as the key. The attribute is not required, but the `modifyChildProps` function otherwise has no way to modify the values emitted from child's `props$`. If there is only one instance of that child type, this isn't a problem, but multiple children need to be distinguished in order to provide the appropriate props.
 
 The value of the attribute should be unique amongst children of the same type in a parent Component. The `render` module also uses this to reuse a Component when it's been moved to a new location but is otherwise the same instance. Rendering a Component with multiple children that share both a type and a key will result in unexpected behavior.

--- a/docs/source/using-a-template-to-render-a-component.md
+++ b/docs/source/using-a-template-to-render-a-component.md
@@ -7,7 +7,7 @@ Now that a Component is emitting events, it needs to update the `Element` it's m
 
 **Note: Any custom render implementations for a Component must use `onMount`, not `render`, as the API for `render` is subject to change.** Use the `render` module to ensure compatibility with future `brookjs` versions.
 
-`brookjs` uses [`morphdom`][morphdom] to update the element from an HTML string, configured to take advantage of `brookjs`' custom attributes, allowing the Component to rely on Handlebars to render itself. Using a bundler like [`webpack`][webpack] and [`handlebars-loader`][hbs-loader] or [`browserify`][browserify] and [`hbsfy`][hbsfy], compile Handlebars imports to a Handlebars template function. Import that function into the Component module and pass it to `render`:
+`brookjs` uses [`diffhtml`][diffhtml] to update the element from an HTML string, configured to take advantage of `brookjs`' custom attributes, allowing a Component to rely on Handlebars to render itself. Using a bundler like [`webpack`][webpack] and [`handlebars-loader`][hbs-loader] or [`browserify`][browserify] and [`hbsfy`][hbsfy], compile Handlebars imports to a Handlebars template function. Import that function into the Component module and pass it to `render`:
 
 ```js
 // app.js
@@ -28,17 +28,13 @@ export default component({
 });
 ```
 
-For now, that's it! Now the Component's element will rerender on the next value from the Component's `Observable<props>`. The provided template function gets called with the emitted `props`, and `morphdom` uses the returned HTML to update the element.
+For now, that's it! Now the Component's element will rerender on the next value from the Component's `Observable<props>`. The provided template function gets called with the emitted `props`, and `diffhtml` uses the returned HTML to update the element.
 
-Note that `render` uses the `data-brk-container` attribute to determine the Component's boundary. This means it's important to ensure each Component has that attribute on its containing element, allowing an individual Component to render itself while parents ensure the node is still present and the same instance (as with iterated children).
+Note that `render` is responsible for the entire element it's provided. Use the Handlebars rendering context to ensure each subcomponent has access to the props it needs to render properly, and any logic should be encoded in Handlebars helpers.
 
-Using the attribute also provides the benefit of allowing a Component to blackbox sections of itself that it know won't update by decorating it with the `data-brk-container` attribute. This way, morphdom will not descend into those sections of the DOM to reconcile with the provided template string.
+If a section of the DOM needs to be hidden from diffhtml, add `data-brk-blackbox="uniqueName"` as a data-attribute to the element. When `diffhtml` goes to update the DOM, any elements with that attribute will not be updated. A unique name is required in order to ensure the element isn't removed from the DOM. Make sure the element with the matching blackbox attribute is included in the rendered template or the element will get removed.
 
-## Roadmap
-
-This modules needs to provide two lifecycle hooks is does not: running an Observable before or after `render` reconciles the DOM (a la `component{Will|Did}Update` in React), as well as before or after it adds or removes nodes during the reconciliation process, providing a easy-to-use abstraction over animating transitions in an application. Observables make it easy to compose complex animations as well as cancel them as new `props` flow into the Component. This is the vision for the `render` module.
-
-  [morphdom]: https://github.com/patrick-steele-idem/morphdom
+  [diffhtml]: https://github.com/tbranyen/diffhtml
   [webpack]: https://webpack.js.org/
   [hbs-loader]: https://github.com/pcardune/handlebars-loader
   [browserify]: http://browserify.org/

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -6,6 +6,8 @@ if (!process.env.NODE_ENV) {
 const R = require('ramda');
 const webpackConfig = R.clone(require('./webpack.config'));
 
+webpackConfig.devtool = 'inline-source-map';
+
 module.exports = function (config) {
     const tests = '!(node_modules)/**/__tests__/*.spec.js';
 

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "webpack-merge": "^2.4.0"
   },
   "dependencies": {
+    "diffhtml": "1.0.0-alpha",
     "kefir": "^3.3.0",
-    "morphdom": "^2.0.1",
     "ramda": "^0.23.0",
     "redux": "^3.5.2"
   }

--- a/src/children/__tests__/children.spec.js
+++ b/src/children/__tests__/children.spec.js
@@ -2,7 +2,7 @@
 import 'core-js/shim';
 
 import { AssertionError } from 'assert';
-import { constant } from 'kefir';
+import { constant, never } from 'kefir';
 
 import chai, { expect } from 'chai';
 import sinon from 'sinon';
@@ -195,5 +195,23 @@ describe('children', () => {
 
             done();
         });
+    });
+
+    it('should use createSourceStream when available', () => {
+        let createSourceStream = sinon.spy(() => never());
+        let { factory, firstChild, instance, modifyChildProps, props$, preplug } = createFixture({ createSourceStream });
+        let sub = instance.observe();
+
+        expect(factory).to.have.callCount(0);
+        expect(createSourceStream).to.have.callCount(1);
+        expect(createSourceStream).to.have.been.calledWith(firstChild, props$);
+
+        expect(modifyChildProps).to.have.callCount(1);
+        expect(modifyChildProps).to.have.been.calledWith(props$, '1');
+
+        expect(preplug).to.have.callCount(1);
+        expect(preplug).to.have.been.calledWith(createSourceStream.getCall(0).returnValue);
+
+        sub.unsubscribe();
     });
 });

--- a/src/children/__tests__/util.js
+++ b/src/children/__tests__/util.js
@@ -1,7 +1,7 @@
 import R from 'ramda';
 import { pool } from 'kefir';
 import sinon from 'sinon';
-import { CONTAINER_ATTRIBUTE, KEY_ATTRIBUTE } from '../../constants';
+import { CONTAINER_ATTRIBUTE, KEY_ATTRIBUTE, $$internals } from '../../constants';
 import children from '../';
 
 /**
@@ -9,9 +9,10 @@ import children from '../';
  *
  * @returns {Fixture} Children test fixture.
  */
-export function createFixture() {
-    let child$ = pool();
-    let factory = sinon.spy(() => child$);
+export function createFixture({ child$ = pool(), factory = sinon.spy(() => child$), createSourceStream } = {}) {
+    if (createSourceStream) {
+        factory[$$internals] = { createSourceStream };
+    }
     let modifyChildProps = sinon.spy(R.identity);
     let preplug = sinon.spy(R.identity);
     let generator = children({ child: { factory, modifyChildProps, preplug } });

--- a/src/children/child.js
+++ b/src/children/child.js
@@ -6,24 +6,23 @@ import { KEY_ATTRIBUTE } from '../constants';
  * Create a new children stream instance from the given configuration, props$ stream & element.
  *
  * @param {string} container - Container key.
+ * @param {Function} createSourceStream - Function that generates a source stream.
  * @param {Function} factory - Instance factory function.
  * @param {Function} modifyChildProps - Creates a new props$ stream for the child.
  * @param {Function} preplug - Modify the child instance stream.
  * @param {string} key - @deprecated.
  * @returns {Kefir.Observable} Child instance.
  */
-export default function child({ container, factory, modifyChildProps = R.identity, preplug = R.identity, key }) {
+export default function child({ container, createSourceStream, factory, modifyChildProps = R.identity, preplug = R.identity }) {
     if (process.env.NODE_ENV !== 'production') {
-        assert.equal(typeof factory, 'function', `factory for ${container} should be a function`);
+        if (createSourceStream) {
+            assert.equal(typeof createSourceStream, 'function', `createSourceStream for ${container} should be a function`);
+        } else {
+            assert.equal(typeof factory, 'function', `factory for ${container} should be a function`);
+        }
+
         assert.equal(typeof modifyChildProps, 'function', `modifyChildProps for ${container} should be a function`);
         assert.equal(typeof preplug, 'function', `preplug for ${container} should be a function`);
-
-        if (key) {
-            console.warn(`Using key in children configuration is deprecated.
-Use the second parameter to modifyChildProps.`);
-
-            assert.equal(typeof key, 'string', `key for ${container} should be a string`);
-        }
     }
 
     /**
@@ -34,43 +33,14 @@ Use the second parameter to modifyChildProps.`);
      * @returns {Kefir.Observable} - Child stream instance.
      */
     return R.curry((element, props$) => {
-        const hasKey = element.hasAttribute(KEY_ATTRIBUTE);
         const keyAttr = element.getAttribute(KEY_ATTRIBUTE);
-        const useKey = key && hasKey;
 
-        let childProps$ = modifyChildProps(props$, keyAttr);
-
-        if (useKey) {
-            if ('@@key' === key) {
-                childProps$ = childProps$.map(R.prop(element.getAttribute(KEY_ATTRIBUTE)));
-            } else {
-                childProps$ = childProps$.map(R.find(
-                    R.pipe(R.path(key.split('.')), R.equals(element.getAttribute(KEY_ATTRIBUTE)))
-                ));
-            }
-
-            // If the key isn't found, then the child is about to
-            // be removed, so don't dispatch props down the stream.
-            // @todo this seems suboptimal. how to handle iterated children?
-            childProps$ = childProps$.filter(
-                R.pipe(R.type, R.equals('Undefined'), R.not)
-            );
-        }
-
-        let instance$ = preplug(factory(element, childProps$), keyAttr);
-
-        if (useKey) {
-            instance$ = instance$.map(action => Object.assign({}, action, {
-                payload: Object.assign({
-                    get key() {
-                        console.warn(`Using key property automatically added to children Actions is deprecated.
-Use the second parameter to preplug to modify child's Action.`);
-                        return element.getAttribute(KEY_ATTRIBUTE);
-                    }
-                }, action.payload)
-            }));
-        }
-
-        return instance$;
+        return preplug(
+            (createSourceStream || factory)(
+                element,
+                modifyChildProps(props$, keyAttr)
+            ),
+            keyAttr
+        );
     });
 }

--- a/src/children/index.js
+++ b/src/children/index.js
@@ -3,6 +3,7 @@ import R from 'ramda';
 import { constant, merge } from 'kefir';
 import child from './child';
 import { containerAttribute } from '../helpers';
+import { $$internals } from '../constants';
 import { getContainerNode, containerMatches, isAddedChildNode, isRemovedChildNode
 } from './util';
 import mutations$ from './mutations';
@@ -40,7 +41,13 @@ export default function children(factories) {
             definition = { factory: definition };
         }
 
-        factories[container] = child(R.merge({ container }, definition));
+        let createSourceStream = false;
+
+        if (definition.factory[$$internals]) {
+            ({ createSourceStream } = definition.factory[$$internals]);
+        }
+
+        factories[container] = child(Object.assign({ container, createSourceStream }, definition));
     }
 
     /**

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -30,7 +30,7 @@ export default function component(config) {
         assert.equal(typeof events, 'function', '`events` should be a function');
 
         // Validate onMount$ stream generator.
-        assert.ok(typeof onMount === 'function', 'onMount should be a function');
+        assert.equal(typeof onMount, 'function', 'onMount should be a function');
 
         // Validate render function.
         assert.equal(typeof render, 'function', '`render` should be a function');
@@ -38,10 +38,10 @@ export default function component(config) {
         assert.equal(render.length, 2, '`render` should take 2 arguments');
 
         // Validate children$ stream generator.
-        assert.ok(children, '`children` should be a function');
+        assert.equal(typeof children, 'function', '`children` should be a function');
 
         // Validate shouldUpdate filter.
-        assert.ok(typeof shouldUpdate === 'function', 'shouldUpdate should be a function');
+        assert.equal(typeof shouldUpdate, 'function', 'shouldUpdate should be a function');
     }
 
     /**

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -1,6 +1,7 @@
 import R from 'ramda';
 import assert from 'assert';
 import { Observable, merge, never } from 'kefir';
+import { $$internals } from '../constants';
 
 /**
  * Create a new Component with the provided configuration.
@@ -44,6 +45,55 @@ export default function component(config) {
         assert.equal(typeof shouldUpdate, 'function', 'shouldUpdate should be a function');
     }
 
+    const internals = {
+
+        /**
+         * Creates a new source stream from the provided element and props stream.
+         * A source stream emits the actions from the element.
+         *
+         * @param {Element} el - Element to create a stream from.
+         * @param {Observable<Props>} props$ - Stream of props.
+         * @returns {Observable<Action>} Stream of actions from the DOM.
+         */
+        createSourceStream(el, props$) {
+            const onMount$ = onMount(el, props$);
+            const events$ = events(el);
+            const children$ = children(el, props$);
+
+            if (process.env.NODE_ENV !== 'production') {
+                assert.ok(children$ instanceof Observable, '`children$` is not a `Kefir.Observable`');
+                assert.ok(events$ instanceof Observable, '`events$` is not a `Kefir.Observable`');
+                assert.ok(onMount$ instanceof Observable, '`onMount$` is not a `Kefir.Observable`');
+            }
+
+            const source$ = combinator({ onMount$, events$, children$ });
+
+            if (process.env.NODE_ENV !== 'production') {
+                assert.ok(source$ instanceof Observable, '`source$` is not a `Kefir.Observable`');
+            }
+
+            return source$;
+        },
+
+        /**
+         * Creates a new sink stream from the provided element and props stream.
+         * A sink stream performs side effects on the element.
+         *
+         * @param {Element} el - Element to create a stream from.
+         * @param {Observable<Props>} props$ - Stream of props.
+         * @returns {Observable<Action>} Stream of actions from the DOM.
+         */
+        createSinkStream(el, props$) {
+            const sink$ = render(el, props$);
+
+            if (process.env.NODE_ENV !== 'production') {
+                assert.ok(sink$ instanceof Observable, '`sink$` is not a `Kefir.Observable`');
+            }
+
+            return sink$;
+        }
+    };
+
     /**
      * Component factory function.
      *
@@ -51,37 +101,19 @@ export default function component(config) {
      * @param {Observable} props$ - Observable of component props.
      * @returns {Observable} Component instance.
      */
-    return R.curry((el, props$) => {
+    const componentFactory = R.curry((el, props$) => {
         if (process.env.NODE_ENV !== 'production') {
             assert.ok(el instanceof HTMLElement, 'el is not an HTMLElement');
             assert.ok(props$ instanceof Observable, '`props$` is not a `Kefir.Observable`');
         }
 
-        const children$ = children(el, props$);
-        const events$ = events(el);
-        const render$ = render(el, props$
-            .slidingWindow(2)
-            .map(R.ifElse(
-                R.pipe(R.length, R.equals(2)),
-                R.identity,
-                R.pipe(R.head, R.repeat(R.__, 2))))
-            .filter(R.apply(shouldUpdate))
-            .map(R.last));
-        const onMount$ = onMount(el, props$);
-
-        if (process.env.NODE_ENV !== 'production') {
-            assert.ok(children$ instanceof Observable, '`children$` is not a `Kefir.Observable`');
-            assert.ok(events$ instanceof Observable, '`events$` is not a `Kefir.Observable`');
-            assert.ok(render$ instanceof Observable, '`render$` is not a `Kefir.Observable`');
-            assert.ok(onMount$ instanceof Observable, '`onMount$` is not a `Kefir.Observable`');
-        }
-
-        const instance$ = combinator({ children$, events$, render$, onMount$ });
-
-        if (process.env.NODE_ENV !== 'production') {
-            assert.ok(instance$ instanceof Observable, '`instance$` is not a `Kefir.Observable`');
-        }
-
-        return instance$;
+        return merge([
+            internals.createSinkStream(el, props$),
+            internals.createSourceStream(el, props$)
+        ]);
     });
+
+    componentFactory[$$internals] = internals;
+
+    return componentFactory;
 };

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -138,3 +138,5 @@ export const EVENT_ATTRIBUTES = {
     [TOUCHEND]: prefix('ontouchend'),
     [TOUCHSTART]: prefix('ontouchstart')
 };
+
+export const $$internals = Symbol('@@brookjs/internals');

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -15,6 +15,15 @@ export const CONTAINER_ATTRIBUTE = 'data-brk-container';
 export const KEY_ATTRIBUTE = 'data-brk-key';
 
 /**
+ * HTML attribute blackbox directive.
+ *
+ * For tagging a section of DOM to not update.
+ *
+ * @type {string}
+ */
+export const BLACKBOX_ATTRIBUTE = 'data-brk-blackbox';
+
+/**
  * Supported event constants.
  *
  * @type {string}

--- a/src/domDelta/__tests__/domDelta.spec.js
+++ b/src/domDelta/__tests__/domDelta.spec.js
@@ -1,0 +1,122 @@
+/* eslint-env mocha */
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { constant, fromCallback, never } from 'kefir';
+
+import domDelta from '../';
+
+chai.use(sinonChai);
+
+describe('domDelta', () => {
+    it('should be a function', () => {
+        expect(domDelta).to.be.a('function');
+    });
+
+    it('should return a delta function', () => {
+        const delta = domDelta({});
+
+        expect(delta).to.be.a('function');
+        expect(delta).to.have.lengthOf(2);
+    });
+
+    it('should emit an error if incorrect el', done => {
+        const actions$ = never();
+        const state$ = never();
+        const delta = domDelta({ el: false });
+
+        const delta$ = delta(actions$, state$);
+
+        let errored;
+
+        delta$.observe({
+            error(err) {
+                errored = true;
+                expect(err).to.be.instanceOf(TypeError);
+            },
+            end() {
+                expect(errored).to.eql(true);
+                done();
+            }
+        });
+    });
+
+    it('should emit an error if incorrect component', done => {
+        const actions$ = never();
+        const state$ = never();
+        const delta = domDelta({ el: document.body, component: false });
+
+        const delta$ = delta(actions$, state$);
+
+        let errored;
+
+        delta$.observe({
+            error(err) {
+                errored = true;
+                expect(err).to.be.instanceOf(TypeError);
+            },
+            end() {
+                expect(errored).to.eql(true);
+                done();
+            }
+        });
+    });
+
+    it('should emit an error if incorrect selectProps', done => {
+        const actions$ = never();
+        const state$ = never();
+        const delta = domDelta({ el: document.body, component: never, selectProps: false });
+
+        const delta$ = delta(actions$, state$);
+
+        let errored;
+
+        delta$.observe({
+            error(err) {
+                errored = true;
+                expect(err).to.be.instanceOf(TypeError);
+            },
+            end() {
+                expect(errored).to.eql(true);
+                done();
+            }
+        });
+    });
+
+    it('should call provided functions with proper args', done => {
+        const actions$ = never();
+        const state$ = never();
+        const props$ = never();
+        const config = {
+            el: sinon.spy(doc => fromCallback(cb => cb(doc.body))),
+            component: sinon.spy(() => constant({ type: 'EVENT' })),
+            selectProps: sinon.spy(() => props$)
+        };
+        const delta = domDelta(config);
+
+        const delta$ = delta(actions$, state$);
+
+        let emitted;
+
+        delta$.observe({
+            value(val) {
+                emitted = true;
+
+                expect(val).to.eql({ type: 'EVENT' });
+            },
+            end() {
+                expect(emitted).to.eql(true);
+
+                expect(config.el).to.have.callCount(1);
+
+                expect(config.selectProps).to.have.callCount(1);
+                expect(config.selectProps).to.have.been.calledWith(state$);
+
+                expect(config.component).to.have.callCount(1);
+                expect(config.component).to.have.been.calledWith(document.body, props$);
+
+                done();
+            }
+        });
+    });
+});

--- a/src/domDelta/index.js
+++ b/src/domDelta/index.js
@@ -1,0 +1,44 @@
+import R from 'ramda';
+import { constant, constantError, fromCallback, fromEvents } from 'kefir';
+
+const documentIsLoaded = () =>
+    fromCallback(callback =>
+        callback(
+            document.readyState === 'complete' ||
+            document.readyState === 'loaded' ||
+            document.readyState === 'interactive'
+        )
+    );
+
+export default function domDelta({ el, component, selectProps }) {
+    let precheck$ = constant('Configuration correct');
+
+    if (typeof el === 'function') {
+        el = el(document);
+    } else if (el instanceof Element) {
+        el = constant(el);
+    } else {
+        precheck$ = constantError(new TypeError(`el of type ${typeof el} is not valid`));
+    }
+
+    if (typeof component !== 'function') {
+        precheck$ = constantError(new TypeError(`component of type ${typeof el} is not valid`));
+    }
+
+    if (typeof selectProps !== 'function') {
+        precheck$ = constantError(new TypeError(`selectProps of type ${typeof el} is not valid`));
+    }
+
+    return (actions$, state$) => {
+        return precheck$
+            .flatMap(documentIsLoaded)
+            .flatMap(isLoaded =>
+                isLoaded ?
+                    constant(true) :
+                    fromEvents(document, 'DOMContentLoaded')
+            )
+            .flatMap(R.always(el))
+            .take(1).takeErrors(1)
+            .flatMap(el => component(el, selectProps(state$)));
+    };
+}

--- a/src/helpers/blackboxAttribute.js
+++ b/src/helpers/blackboxAttribute.js
@@ -1,0 +1,5 @@
+import { BLACKBOX_ATTRIBUTE } from '../constants';
+
+export default function blackboxAttribute(container) {
+    return `${BLACKBOX_ATTRIBUTE}="${container}"`;
+}

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,3 +1,4 @@
+export { default as blackboxAttribute } from './blackboxAttribute';
 export { default as containerAttribute } from './containerAttribute';
 export { default as keyAttribute } from './keyAttribute';
 export { default as createFixture } from './createFixture';

--- a/src/index.js
+++ b/src/index.js
@@ -2,17 +2,18 @@ import { RAF, rafAction } from './action';
 import children from './children';
 import combineActionReducers from './combineActionReducers';
 import component from './component';
+import domDelta from './domDelta';
 import events from './events';
 import observeDelta from './observeDelta';
 import { containerAttribute, createFixture, eventAttribute,
     mapActionTo } from './helpers';
 import render, { raf$, renderFromHTML } from './render';
 
-const brook = { children, combineActionReducers, component, events,
+const brook = { children, combineActionReducers, component, events, domDelta,
     observeDelta, containerAttribute, createFixture, eventAttribute,
     mapActionTo, render, RAF, rafAction, raf$, renderFromHTML };
 
-export { brook, children, combineActionReducers, component, events,
+export { brook, children, combineActionReducers, component, events, domDelta,
     observeDelta, containerAttribute, createFixture, eventAttribute,
     mapActionTo, render, RAF, rafAction, raf$, renderFromHTML };
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ const brook = { children, combineActionReducers, component, events, domDelta,
     observeDelta, containerAttribute, createFixture, eventAttribute,
     mapActionTo, render, RAF, rafAction, raf$, renderFromHTML };
 
-export { brook, children, combineActionReducers, component, events, domDelta,
+export { children, combineActionReducers, component, events, domDelta,
     observeDelta, containerAttribute, createFixture, eventAttribute,
     mapActionTo, render, RAF, rafAction, raf$, renderFromHTML };
 

--- a/src/observeDelta/__tests__/observeDelta.spec.js
+++ b/src/observeDelta/__tests__/observeDelta.spec.js
@@ -34,6 +34,7 @@ describe('enhancer', function() {
     it('should call the delta with actions$ and state$', function() {
         expect(actions$).to.be.an.instanceof(Observable);
         expect(state$).to.be.an.instanceof(Observable);
+        expect(actions$.ofType).to.be.a('function');
     });
 
     it('should dispatch action to actions$', function() {
@@ -77,7 +78,6 @@ describe('enhancer', function() {
 
         delta$.plug(constant(action));
 
-        expect(store.closed).to.be.not.ok;
         expect(subscribe).to.be.calledOnce;
     });
 

--- a/src/observeDelta/index.js
+++ b/src/observeDelta/index.js
@@ -22,6 +22,31 @@ export default function observeDelta(...sources) {
     const actions$ = pool();
     const state$ = pool();
 
+    /**
+     * Filter the actions$ stream to just emit actions of
+     * the provided types.
+     *
+     * @param {Array<string>} types - Action types to filter.
+     * @returns {Observable<Action>} Stream of filtered actions.
+     */
+    actions$.ofType = function ofType(...types) {
+        return this.filter(action => {
+            const type = action.type;
+            const len = types.length;
+
+            if (len === 1) {
+                return type === types[0];
+            } else {
+                for (let i = 0; i < len; i++) {
+                    if (types[i] === type) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        });
+    };
+
     return store => {
         store.subscription = merge(sources.map(source => source(actions$, state$.toProperty(store.getState))))
             .observe({ value: store.dispatch });

--- a/src/render/__tests__/render.spec.js
+++ b/src/render/__tests__/render.spec.js
@@ -1,4 +1,9 @@
 /* eslint-env mocha */
+import 'core-js/fn/map';
+import 'core-js/fn/promise';
+import 'core-js/fn/set';
+import 'core-js/fn/array/includes';
+import 'core-js/fn/string/includes';
 import { AssertionError } from 'assert';
 import chai, { expect } from 'chai';
 import dom from 'chai-dom';
@@ -114,6 +119,7 @@ describe('render', function() {
             expect(template).to.have.been.calledWithExactly(next);
 
             expect(fixture.children).to.have.lengthOf(2);
+            expect(child.parentNode).to.eql(fixture);
             expect(child2.parentNode).to.eql(null);
 
             sub.unsubscribe();

--- a/src/render/__tests__/render.spec.js
+++ b/src/render/__tests__/render.spec.js
@@ -10,8 +10,8 @@ import dom from 'chai-dom';
 import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 
-import { CONTAINER_ATTRIBUTE, KEY_ATTRIBUTE } from '../../constants';
-import { containerAttribute, keyAttribute } from '../../helpers';
+import { CONTAINER_ATTRIBUTE, KEY_ATTRIBUTE, BLACKBOX_ATTRIBUTE } from '../../constants';
+import { blackboxAttribute, containerAttribute, keyAttribute } from '../../helpers';
 import render from '../';
 
 import { constant, pool } from 'kefir';
@@ -24,7 +24,7 @@ describe('render', function() {
         type: 'text',
         text: 'Hello world!'
     };
-    let template, next, fixture, generator, props$, child, span;
+    let template, next, fixture, generator, props$, child, span, blackboxed;
 
     beforeEach(function() {
         props$ = pool();
@@ -32,11 +32,7 @@ describe('render', function() {
             type: 'image',
             text: 'A picture'
         };
-        template = sinon.spy(() =>
-`<div ${containerAttribute('parent')} class="image">
-    <span>A picture</span>
-    <span ${containerAttribute('child')} ${keyAttribute('one')}>Not a picture.</span>
-</div>`);
+        template = sinon.spy(() => `<div ${containerAttribute('parent')} class="image"><span>A picture</span><span ${containerAttribute('child')} ${keyAttribute('one')}>Not a picture</span><span ${blackboxAttribute('hidden')}>This should not appear.</span></div>`);
 
         fixture = document.createElement('div');
         fixture.classList.add(initial.type);
@@ -51,6 +47,11 @@ describe('render', function() {
         child.setAttribute(KEY_ATTRIBUTE, 'one');
         child.textContent = 'Picture description';
         fixture.appendChild(child);
+
+        blackboxed = document.createElement('span');
+        blackboxed.setAttribute(BLACKBOX_ATTRIBUTE, 'hidden');
+        blackboxed.textContent = 'This should stay.';
+        fixture.appendChild(blackboxed);
 
         generator = render(template);
     });
@@ -84,7 +85,7 @@ describe('render', function() {
         });
     });
 
-    it('should not update child container element', done => {
+    it('should update child container element', done => {
         const render$ = generator(fixture, props$);
 
         const sub = render$.observe({});
@@ -94,7 +95,7 @@ describe('render', function() {
             expect(template).to.have.callCount(1);
             expect(template).to.have.been.calledWithExactly(next);
 
-            expect(child).to.have.text('Picture description');
+            expect(child).to.have.text('Not a picture');
 
             sub.unsubscribe();
 
@@ -118,7 +119,7 @@ describe('render', function() {
             expect(template).to.have.callCount(1);
             expect(template).to.have.been.calledWithExactly(next);
 
-            expect(fixture.children).to.have.lengthOf(2);
+            expect(fixture.children).to.have.lengthOf(3);
             expect(child.parentNode).to.eql(fixture);
             expect(child2.parentNode).to.eql(null);
 
@@ -139,7 +140,73 @@ describe('render', function() {
             expect(template).to.have.callCount(1);
             expect(template).to.have.been.calledWithExactly(next);
 
-            expect(fixture.children).to.have.lengthOf(2);
+            expect(fixture.children).to.have.lengthOf(3);
+
+            sub.unsubscribe();
+
+            done();
+        });
+    });
+
+    it('should not update blackboxed element', done => {
+        const render$ = generator(fixture, props$);
+
+        const sub = render$.observe({});
+        props$.plug(constant(next));
+
+        requestAnimationFrame(() => {
+            setTimeout(() => {
+                expect(template).to.have.callCount(1);
+                expect(template).to.have.been.calledWithExactly(next);
+
+                expect(blackboxed.parentNode).to.eql(fixture);
+                expect(blackboxed).to.have.text('This should stay.');
+
+                sub.unsubscribe();
+
+                done();
+            }, 500);
+        });
+    });
+
+    it('should remove extra blackboxed element', done => {
+        let blackboxed2 = document.createElement('span');
+        blackboxed2.setAttribute(BLACKBOX_ATTRIBUTE, 'removed');
+        blackboxed2.textContent = 'Another blackboxed element.';
+        fixture.appendChild(blackboxed2);
+
+        const render$ = generator(fixture, props$);
+
+        const sub = render$.observe({});
+        props$.plug(constant(next));
+
+        requestAnimationFrame(() => {
+            expect(template).to.have.callCount(1);
+            expect(template).to.have.been.calledWithExactly(next);
+
+            expect(fixture.children).to.have.lengthOf(3);
+            expect(child.parentNode).to.eql(fixture);
+            expect(blackboxed2.parentNode).to.eql(null);
+
+            sub.unsubscribe();
+
+            done();
+        });
+    });
+
+    it('should add missing blackboxed element', done => {
+        fixture.removeChild(blackboxed);
+        const render$ = generator(fixture, props$);
+
+        const sub = render$.observe({});
+        props$.plug(constant(next));
+
+        requestAnimationFrame(() => {
+            expect(template).to.have.callCount(1);
+            expect(template).to.have.been.calledWithExactly(next);
+
+            expect(fixture.children).to.have.lengthOf(3);
+            expect(fixture.children[2]).to.have.text('This should not appear.');
 
             sub.unsubscribe();
 

--- a/src/render/endAsObservable.js
+++ b/src/render/endAsObservable.js
@@ -1,0 +1,22 @@
+import { fromPromise, stream } from 'kefir';
+
+/**
+ * Terminate the transaction by returning an Observable instead of a Promise.
+ *
+ * @param {Transaction} transaction - Transaction object.
+ * @returns {Observable} Render observable.
+ */
+export default function endAsObservable(transaction) {
+    const { promises = [] } = transaction;
+
+    const end$ = stream(emitter => {
+        transaction.end();
+        emitter.end();
+    });
+
+    if (!promises.length) {
+        return end$;
+    }
+
+    return fromPromise(Promise.all(promises)).ignoreValues().concat(end$);
+}

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -1,9 +1,11 @@
 import assert from 'assert';
 import { rafAction } from '../action';
-import { CONTAINER_ATTRIBUTE, KEY_ATTRIBUTE } from '../constants';
+import { outerHTML, use } from 'diffhtml';
 import R from 'ramda';
-import { stream } from 'kefir';
-import morphdom from 'morphdom';
+import { fromPromise, stream } from 'kefir';
+import renderMiddleware from './middleware';
+
+use(renderMiddleware());
 
 /**
  * Stream of requestAnimationFrame events.
@@ -41,87 +43,13 @@ export const raf$ = stream(emitter => {
  * @returns {Kefir.Observable} Render stream.
  */
 export const renderFromHTML = R.curry((el, html) =>
-    raf$.take(1).flatMap(() => stream(emitter => {
+    raf$.take(1).flatMap(() => {
         if (process.env.NODE_ENV !== 'production') {
             assert.equal(typeof html, 'string', '`template` should return a string');
         }
 
-        morphdom(el, html, {
-            getNodeKey: function getNodeKey(el) {
-                if (el.hasAttribute && el.hasAttribute(CONTAINER_ATTRIBUTE) && el.hasAttribute(KEY_ATTRIBUTE)) {
-                    return `${el.getAttribute(CONTAINER_ATTRIBUTE)}::${el.getAttribute(KEY_ATTRIBUTE)}`;
-                }
-
-                return '';
-            },
-            onBeforeElUpdated: function blackboxContainer(fromEl, toEl) {
-                /**
-                 * Always update the top level element.
-                 *
-                 * We're making a few assumptions about the main element
-                 * and its relationship to the returned template:
-                 *
-                 * 1. The container type of the template already matches
-                 * the container type of the element. This should be matched
-                 * correctly when the element is mounted.
-                 *
-                 * 2. The key of the template already matches the key of
-                 * the element. If there is no key on either, then the
-                 * attribute is `null`. This should be matched correctly
-                 * using `modifyChildProps` to emit the props with the
-                 * correct key, assuming the use of the default render.
-                 *
-                 * These assumptions get verified below outside of production.
-                 */
-                if (fromEl === el) {
-                    if (process.env.NODE_ENV !== 'production') {
-                        assert.equal(
-                            el.getAttribute(CONTAINER_ATTRIBUTE),
-                            fromEl.getAttribute(CONTAINER_ATTRIBUTE),
-                            `The template ${CONTAINER_ATTRIBUTE} should match the root element ${CONTAINER_ATTRIBUTE}.`
-                        );
-                        assert.equal(
-                            el.getAttribute(KEY_ATTRIBUTE),
-                            fromEl.getAttribute(KEY_ATTRIBUTE),
-                            `The template ${KEY_ATTRIBUTE} should match the root element ${KEY_ATTRIBUTE}.`
-                        );
-                    }
-
-                    return true;
-                }
-
-                // Update anything that isn't a container.
-                if (!fromEl.hasAttribute(CONTAINER_ATTRIBUTE)) {
-                    return true;
-                }
-
-                /**
-                 * If it is a container, we're going to do our own updating
-                 * and tell morphdom to move on.
-                 *
-                 * If the container has changed, swap element ourselves.
-                 * This is similar to how React handles it: If a subtree
-                 * is a different component, it just prunes and replaces,
-                 * since the subtree could be different in myriad different
-                 * ways and a full diff would be computationally
-                 * expensive. Additionally, this allows the MutationObserver
-                 * to continue to only worry about add/remove operations
-                 * instead of attribute mutations.
-                 */
-                if (fromEl.getAttribute(CONTAINER_ATTRIBUTE) !== toEl.getAttribute(CONTAINER_ATTRIBUTE) ||
-                    fromEl.getAttribute(KEY_ATTRIBUTE) !== toEl.getAttribute(KEY_ATTRIBUTE)
-                ) {
-                    fromEl.parentNode.replaceChild(toEl, fromEl);
-                }
-
-                // Tell morphdom to move on.
-                return false;
-
-            }
-        });
-
-        emitter.end();
-    })));
+        return fromPromise(outerHTML(el, html));
+    }));
 
 /**
  * Generates a new rendering stream that ends after the element is updated.

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 import { rafAction } from '../action';
 import { outerHTML, use } from 'diffhtml';
 import R from 'ramda';
-import { fromPromise, stream } from 'kefir';
+import { stream } from 'kefir';
 import renderMiddleware from './middleware';
 
 use(renderMiddleware());
@@ -48,7 +48,7 @@ export const renderFromHTML = R.curry((el, html) =>
             assert.equal(typeof html, 'string', '`template` should return a string');
         }
 
-        return fromPromise(outerHTML(el, html));
+        return outerHTML(el, html);
     }));
 
 /**

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -16,10 +16,9 @@ use(renderMiddleware());
  */
 export const raf$ = stream(emitter => {
     let loop;
-    let enabled = false;
+    let enabled = true;
 
     (function schedule() {
-        enabled = true;
         loop = requestAnimationFrame(time => {
             emitter.value(rafAction(time));
 

--- a/src/render/middleware.js
+++ b/src/render/middleware.js
@@ -1,0 +1,85 @@
+import { NodeCache } from 'diffhtml/util';
+import { CONTAINER_ATTRIBUTE, KEY_ATTRIBUTE } from '../constants';
+
+/**
+ * Create an instance of the render middleware for diffhtml.
+ *
+ * @returns {renderTask} Render task middleware.
+ */
+export default function renderMiddleware() {
+    let currentTransaction;
+
+    /**
+     * Maintains the current transaction, overwrites
+     * the built in patch function with our observable
+     * handling.
+     *
+     * @param {Transaction} transaction - Incoming transaction.
+     * @returns {Function} Post-transaction callback.
+     */
+    function renderTask(transaction) {
+        currentTransaction = transaction;
+
+        return () => {
+            currentTransaction = undefined;
+        };
+    }
+
+    /**
+     * Adds the key for every newly created tree.
+     *
+     * @param {VTree} tree - New tree.
+     * @returns {VTree} Updated tree.
+     */
+    renderTask.createTreeHook = tree => {
+        if (tree.attributes[CONTAINER_ATTRIBUTE] && tree.attributes[KEY_ATTRIBUTE]) {
+            tree.key = `${tree.attributes[CONTAINER_ATTRIBUTE]}::${tree.attributes[KEY_ATTRIBUTE]}`;
+        } else {
+            // Tree should not have an attribute if above condition doesn't match.
+            tree.key = '';
+        }
+
+        return tree;
+    };
+
+    /**
+     * Check if the component is a child
+     *
+     * @param {VTree} oldTree - Current tree state.
+     * @param {VTree} newTree - New tree state.
+     * @returns {VTree} Updated tree state.
+     */
+    renderTask.syncTreeHook = (oldTree, newTree) => {
+        // If this is a new tree, we're going to copy anything.
+        if (!oldTree) {
+            return newTree;
+        }
+
+        if (typeof newTree.attributes[CONTAINER_ATTRIBUTE] === 'undefined') {
+            return newTree;
+        }
+
+        if (newTree.attributes[CONTAINER_ATTRIBUTE] !== oldTree.attributes[CONTAINER_ATTRIBUTE]) {
+            return newTree;
+        }
+
+        // If it has a key, then it has a data-brk-key attribute, which
+        // means the keys have to match for them to be the same tree.
+        if (newTree.key && newTree.key !== oldTree.key) {
+            return newTree;
+        }
+
+        // The root node's tree needs to be updated.
+        const existingNode = NodeCache.get(oldTree) || NodeCache.get(newTree);
+        if (existingNode && existingNode === currentTransaction.domNode) {
+            return newTree;
+        }
+
+        // If all these conditions are met, then we have found a child
+        // container that should not be updated.
+        return oldTree;
+
+    };
+
+    return renderTask;
+}

--- a/src/render/middleware.js
+++ b/src/render/middleware.js
@@ -1,5 +1,5 @@
-import { NodeCache } from 'diffhtml/util';
-import { CONTAINER_ATTRIBUTE, KEY_ATTRIBUTE } from '../constants';
+import { BLACKBOX_ATTRIBUTE, CONTAINER_ATTRIBUTE, KEY_ATTRIBUTE } from '../constants';
+import endAsObservable from './endAsObservable';
 
 /**
  * Create an instance of the render middleware for diffhtml.
@@ -7,22 +7,15 @@ import { CONTAINER_ATTRIBUTE, KEY_ATTRIBUTE } from '../constants';
  * @returns {renderTask} Render task middleware.
  */
 export default function renderMiddleware() {
-    let currentTransaction;
-
     /**
      * Maintains the current transaction, overwrites
      * the built in patch function with our observable
      * handling.
      *
      * @param {Transaction} transaction - Incoming transaction.
-     * @returns {Function} Post-transaction callback.
      */
     function renderTask(transaction) {
-        currentTransaction = transaction;
-
-        return () => {
-            currentTransaction = undefined;
-        };
+        transaction.tasks.push(endAsObservable);
     }
 
     /**
@@ -66,8 +59,6 @@ export default function renderMiddleware() {
         }
 
         return newTree;
-
-
     };
 
     return renderTask;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,7 +18,8 @@ const common = {
     resolve: {
         mainFields: ['module', 'jsnext:main', 'browser', 'main'],
         alias: {
-            handlebars: 'handlebars/dist/cjs/handlebars'
+            handlebars: 'handlebars/dist/cjs/handlebars',
+            diffhtml: 'diffhtml/lib'
         }
     }
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,11 +24,6 @@ const common = {
 };
 
 switch (process.env.npm_lifecycle_event) {
-    case 'test:unit':
-        module.exports = merge({
-            devtool: 'inline-source-map'
-        }, common);
-        break;
     case 'build:umd:min':
         module.exports = merge({
             output: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1271,6 +1271,10 @@ diff@^3.1.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
+diffhtml@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/diffhtml/-/diffhtml-0.9.2.tgz#c873f89b6d050b18ad0bf372328ed3bd87f6b647"
+
 diffie-hellman@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"
@@ -2713,10 +2717,6 @@ mocha@^3.2.0:
     lodash.create "3.1.1"
     mkdirp "0.5.1"
     supports-color "3.1.2"
-
-morphdom@^2.0.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/morphdom/-/morphdom-2.3.1.tgz#94247c316360b92cee49e529815370763e27da90"
 
 ms@0.7.1:
   version "0.7.1"


### PR DESCRIPTION
This PR will switch us from morphdom -> diffhtml, and setup diffhtml
as the "source of truth" for the DOM, allowing us to manage all of the
children through the diffhtml middleware. We _could_ also set up the
children stream through diffhtml middleware, rather than a
MutationObserver, with the events

This PR may also include some new functions to handle bootstrapping
a new brookjsapplication, which we may tie into a new method for wiring
up the root component through a new viewDelta.
