### PR TITLE
Fix indexOf check for new nodes

### DIFF
--- a/src/children/mutations.js
+++ b/src/children/mutations.js
@@ -101,8 +101,8 @@ function mapRecordsToActions(record) {
  * @returns {Array<Action>} New list of actions.
  */
 function accumulateUniqueNodes(acc, action) {
-    const listOfNodes = acc.map(R.prop('node'));
-    const indexOfNode = listOfNodes.indexOf(action.node);
+    const listOfNodes = acc.map(R.path(['payload', 'node']));
+    const indexOfNode = listOfNodes.indexOf(action.payload.node);
 
     if (indexOfNode !== -1) {
         // Since there are only two types of actions, if they


### PR DESCRIPTION
The nodes are attached to the payload, not the action itself, so this
ensures we grab it from the right place.