### PR TITLE
Log all errors emitted into the delta

### DIFF
--- a/src/observeDelta/index.js
+++ b/src/observeDelta/index.js
@@ -1,4 +1,4 @@
-import { constant, merge, pool } from 'kefir';
+import { constant, merge, pool, stream } from 'kefir';
 
 /**
  * Accepts a set of delta generator functions and returns a
@@ -24,6 +24,10 @@ export default function observeDelta(...sources) {
 
     return store => {
         store.subscription = merge(sources.map(source => source(actions$, state$.toProperty(store.getState))))
+            .flatMapErrors(err => stream(emitter => {
+                console.error('Error emitted into delta', err);
+                emitter.end();
+            }))
             .observe({ value: store.dispatch });
 
         return next => action => {


### PR DESCRIPTION
The store doesn't handle errors, and errors emitted from the delta
into the store just... disappear. This should improve the developer
experience, as errors emitted from, say, an ajax request that isn't
handled in the delta would produce no discernible side effect.