### PR TITLE
Extract internals object and attach to factory

### DIFF
--- a/docs/source/component.md
+++ b/docs/source/component.md
@@ -82,7 +82,7 @@ _Note: **All functions must be curried.** `brookjs` relies on [`ramda`][ramda] f
         * `{Kefir.Observable}` Observable of events from the children. Does not need to end.
 * `{Function}` combinator - Hook to combine streams before returning them from the factory. Merges the streams by default.
     * Paramters:
-        * `{Object}` streams - Object containing a property for each component stream, including `events$`, `render$`, `children$`, and `onMount$`. Should return a new stream combining the provided events. Provides a hook to coordinate stream events, if necessary.
+        * `{Object}` streams - Object containing a property for each component stream, including `events$`, `children$`, and `onMount$`. Should return a new stream combining the provided events. Provides a hook to coordinate stream events, if necessary.
 * `{Function}` onMount - `onMount$` stream returning function. Called once, when the component is mounted, providing an entry point for any custom event or render logic.
     * Parameters:
         * `{Element}` el - Componenent element.

--- a/src/component/index.js
+++ b/src/component/index.js
@@ -1,6 +1,7 @@
 import R from 'ramda';
 import assert from 'assert';
 import { Observable, merge, never } from 'kefir';
+import { $$internals } from '../constants';
 
 /**
  * Create a new Component with the provided configuration.
@@ -44,6 +45,55 @@ export default function component(config) {
         assert.ok(typeof shouldUpdate === 'function', 'shouldUpdate should be a function');
     }
 
+    const internals = {
+
+        /**
+         * Creates a new source stream from the provided element and props stream.
+         * A source stream emits the actions from the element.
+         *
+         * @param {Element} el - Element to create a stream from.
+         * @param {Observable<Props>} props$ - Stream of props.
+         * @returns {Observable<Action>} Stream of actions from the DOM.
+         */
+        createSourceStream(el, props$) {
+            const onMount$ = onMount(el, props$);
+            const events$ = events(el);
+            const children$ = children(el, props$);
+
+            if (process.env.NODE_ENV !== 'production') {
+                assert.ok(children$ instanceof Observable, '`children$` is not a `Kefir.Observable`');
+                assert.ok(events$ instanceof Observable, '`events$` is not a `Kefir.Observable`');
+                assert.ok(onMount$ instanceof Observable, '`onMount$` is not a `Kefir.Observable`');
+            }
+
+            const source$ = combinator({ onMount$, events$, children$ });
+
+            if (process.env.NODE_ENV !== 'production') {
+                assert.ok(source$ instanceof Observable, '`source$` is not a `Kefir.Observable`');
+            }
+
+            return source$;
+        },
+
+        /**
+         * Creates a new sink stream from the provided element and props stream.
+         * A sink stream performs side effects on the element.
+         *
+         * @param {Element} el - Element to create a stream from.
+         * @param {Observable<Props>} props$ - Stream of props.
+         * @returns {Observable<Action>} Stream of actions from the DOM.
+         */
+        createSinkStream(el, props$) {
+            const sink$ = render(el, props$);
+
+            if (process.env.NODE_ENV !== 'production') {
+                assert.ok(sink$ instanceof Observable, '`sink$` is not a `Kefir.Observable`');
+            }
+
+            return sink$;
+        }
+    };
+
     /**
      * Component factory function.
      *
@@ -51,37 +101,19 @@ export default function component(config) {
      * @param {Observable} props$ - Observable of component props.
      * @returns {Observable} Component instance.
      */
-    return R.curry((el, props$) => {
+    const componentFactory = R.curry((el, props$) => {
         if (process.env.NODE_ENV !== 'production') {
             assert.ok(el instanceof HTMLElement, 'el is not an HTMLElement');
             assert.ok(props$ instanceof Observable, '`props$` is not a `Kefir.Observable`');
         }
 
-        const children$ = children(el, props$);
-        const events$ = events(el);
-        const render$ = render(el, props$
-            .slidingWindow(2)
-            .map(R.ifElse(
-                R.pipe(R.length, R.equals(2)),
-                R.identity,
-                R.pipe(R.head, R.repeat(R.__, 2))))
-            .filter(R.apply(shouldUpdate))
-            .map(R.last));
-        const onMount$ = onMount(el, props$);
-
-        if (process.env.NODE_ENV !== 'production') {
-            assert.ok(children$ instanceof Observable, '`children$` is not a `Kefir.Observable`');
-            assert.ok(events$ instanceof Observable, '`events$` is not a `Kefir.Observable`');
-            assert.ok(render$ instanceof Observable, '`render$` is not a `Kefir.Observable`');
-            assert.ok(onMount$ instanceof Observable, '`onMount$` is not a `Kefir.Observable`');
-        }
-
-        const instance$ = combinator({ children$, events$, render$, onMount$ });
-
-        if (process.env.NODE_ENV !== 'production') {
-            assert.ok(instance$ instanceof Observable, '`instance$` is not a `Kefir.Observable`');
-        }
-
-        return instance$;
+        return merge([
+            internals.createSinkStream(el, props$),
+            internals.createSourceStream(el, props$)
+        ]);
     });
+
+    componentFactory[$$internals] = internals;
+
+    return componentFactory;
 };

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -138,3 +138,5 @@ export const EVENT_ATTRIBUTES = {
     [TOUCHEND]: prefix('ontouchend'),
     [TOUCHSTART]: prefix('ontouchstart')
 };
+
+export const $$internals = Symbol('@@brookjs/internals');


### PR DESCRIPTION
The Symbol allows us to hold onto some metadata about the
component. We'll start by breaking apart the component
generation into a sink & source stream. We're going to update the
`children` stream to only handle children as sources, allowing the
main component to be mounted and handle the entire rendering
context rather than switching rendering contexts between BE & FE.

Add to release notes:

```markdown
* **BREAKING**: Remove `render$` from combinator in `component`. This is a result of a change in the internals, which we're sets up an incoming change in the rendering context.
```