### PR TITLE
Simplify raf$ stream

### DIFF
--- a/src/render/index.js
+++ b/src/render/index.js
@@ -14,10 +14,9 @@ import morphdom from 'morphdom';
  */
 export const raf$ = stream(emitter => {
     let loop;
-    let enabled = false;
+    let enabled = true;
 
     (function schedule() {
-        enabled = true;
         loop = requestAnimationFrame(time => {
             emitter.value(rafAction(time));
 


### PR DESCRIPTION
We don't need to keep re-enabling it. Just enable it at the start and
disable during cleanup.