### PR TITLE
Modify rendering context to be top-down

### DIFF
--- a/docs/source/children.md
+++ b/docs/source/children.md
@@ -55,12 +55,12 @@ export default children({
         // factory function for child taking el & props$
         factory: kid,
         // passed parents' `props$` stream & child key.
-        // return value is passed to child factory.
-        // see below for key docuentation.
+        // return value is passed to child onMount.
+        // see below for key documentation.
         modifyChildProps: (props$, key) => props$.map(props => props.children[key]),
         // passed each child instance to modify child stream
         // return value is plugged into combined string (hence `preplug`)
-        preplug: kid$ => kid$.map(mapActionTo(CHILD_ACTION, PARENT_ACTION))
+        preplug: (kid$, key) => kid$.map(mapActionTo(CHILD_ACTION, PARENT_ACTION)).map(action => Object.assign({}, action, { meta: { key } }))
     }
 });
 ```
@@ -100,4 +100,4 @@ The parent is then responsible for iterating over the props and rendering the ch
 </div>
 ```
 
-For each child, when it's mounted or added to the DOM, `modifyChildProps` is called with the parent's `props$` stream and the value of the child's key attribute. The returned stream should be of the child's props.
+For each child, when it's mounted or added to the DOM, `modifyChildProps` is called with the parent's `props$` stream and the value of the child's key attribute. The returned stream should be of the child's props. This is primarily useful to provide the correct props to the child's `onMount` function.

--- a/docs/source/component.md
+++ b/docs/source/component.md
@@ -83,7 +83,7 @@ _Note: **All functions must be curried.** `brookjs` relies on [`ramda`][ramda] f
 * `{Function}` combinator - Hook to combine streams before returning them from the factory. Merges the streams by default.
     * Paramters:
         * `{Object}` streams - Object containing a property for each component stream, including `events$`, `children$`, and `onMount$`. Should return a new stream combining the provided events. Provides a hook to coordinate stream events, if necessary.
-* `{Function}` onMount - `onMount$` stream returning function. Called once, when the component is mounted, providing an entry point for any custom event or render logic.
+* `{Function}` onMount - `onMount$` stream returning function. Called once, when the component is mounted, providing an entry point for any custom events. `onMount` should avoid doing any direct DOM manipulation unless the component is blackboxed, in which case, `onMount` can provide custom render logic as well.
     * Parameters:
         * `{Element}` el - Componenent element.
         * `{Kefir.Observable}` props$ - Observable of props. Used to render children.

--- a/docs/source/managing-children-components-in-a-component.md
+++ b/docs/source/managing-children-components-in-a-component.md
@@ -55,7 +55,10 @@ export default component({
             modifyChildProps: (props$, key) => props$.map(mapToChildProps),
             preplug: (child$, key) => child$.map(action => {
                 if (action.type === 'CLICK') {
-                    action = Object.assign({}, action, { type: 'SUBMIT_CLICK'});
+                    action = Object.assign({}, action, {
+                        type: 'SUBMIT_CLICK',
+                        meta: { key }
+                    });
                 }
 
                 return action;
@@ -67,6 +70,6 @@ export default component({
 
 ## A Note About the `data-brk-key` Attribute
 
-If a Component is going to be iterated over in a parent, the `data-brk-key` attribute is recommended for both performance and disambiguation reasons. If the child element doesn't have the attribute, the above two functions will be called with `null` as the key. The attribute is not required, but the `modifyChildProps` function otherwise has no way to modify the values emitted from child's `props$`. If there is only one instance of that child type, this isn't a problem, but multiple children need to be distinguished in order to provide the appropriate props.
+If a Component is going to be iterated over in a parent, the `data-brk-key` attribute is recommended for performance. If the child element doesn't have the attribute, the above two functions will be called with `null` as the key. The attribute is not required, but the `modifyChildProps` function otherwise has no way to modify the values emitted from child's `props$`. If there is only one instance of that child type, this isn't a problem, but multiple children need to be distinguished in order to provide the appropriate props.
 
 The value of the attribute should be unique amongst children of the same type in a parent Component. The `render` module also uses this to reuse a Component when it's been moved to a new location but is otherwise the same instance. Rendering a Component with multiple children that share both a type and a key will result in unexpected behavior.

--- a/docs/source/using-a-template-to-render-a-component.md
+++ b/docs/source/using-a-template-to-render-a-component.md
@@ -7,7 +7,7 @@ Now that a Component is emitting events, it needs to update the `Element` it's m
 
 **Note: Any custom render implementations for a Component must use `onMount`, not `render`, as the API for `render` is subject to change.** Use the `render` module to ensure compatibility with future `brookjs` versions.
 
-`brookjs` uses [`morphdom`][morphdom] to update the element from an HTML string, configured to take advantage of `brookjs`' custom attributes, allowing the Component to rely on Handlebars to render itself. Using a bundler like [`webpack`][webpack] and [`handlebars-loader`][hbs-loader] or [`browserify`][browserify] and [`hbsfy`][hbsfy], compile Handlebars imports to a Handlebars template function. Import that function into the Component module and pass it to `render`:
+`brookjs` uses [`morphdom`][morphdom] to update the element from an HTML string, configured to take advantage of `brookjs`' custom attributes, allowing a Component to rely on Handlebars to render itself. Using a bundler like [`webpack`][webpack] and [`handlebars-loader`][hbs-loader] or [`browserify`][browserify] and [`hbsfy`][hbsfy], compile Handlebars imports to a Handlebars template function. Import that function into the Component module and pass it to `render`:
 
 ```js
 // app.js
@@ -28,18 +28,15 @@ export default component({
 });
 ```
 
-For now, that's it! Now the Component's element will rerender on the next value from the Component's `Observable<props>`. The provided template function gets called with the emitted `props`, and `morphdom` uses the returned HTML to update the element.
+For now, that's it! Now the Component's element will rerender on the next value from the Component's `Observable<props>`. The provided template function gets called with the emitted `props`, and `morpdom` uses the returned HTML to update the element.
 
-Note that `render` uses the `data-brk-container` attribute to determine the Component's boundary. This means it's important to ensure each Component has that attribute on its containing element, allowing an individual Component to render itself while parents ensure the node is still present and the same instance (as with iterated children).
+Note that `render` is responsible for the entire element it's provided. Use the Handlebars rendering context to ensure each subcomponent has access to the props it needs to render properly, and any logic should be encoded in Handlebars helpers.
 
-Using the attribute also provides the benefit of allowing a Component to blackbox sections of itself that it know won't update by decorating it with the `data-brk-container` attribute. This way, morphdom will not descend into those sections of the DOM to reconcile with the provided template string.
+If a section of the DOM needs to be hidden from `morpdom`, add `data-brk-blackbox="uniqueName"` as a data-attribute to the element. When `morpdom` goes to update the DOM, any elements with that attribute will not be updated. A unique name is required in order to ensure the element isn't removed from the DOM. Make sure the element with the matching blackbox attribute is included in the rendered template or the element will get removed.
 
-## Roadmap
 
-This modules needs to provide two lifecycle hooks is does not: running an Observable before or after `render` reconciles the DOM (a la `component{Will|Did}Update` in React), as well as before or after it adds or removes nodes during the reconciliation process, providing a easy-to-use abstraction over animating transitions in an application. Observables make it easy to compose complex animations as well as cancel them as new `props` flow into the Component. This is the vision for the `render` module.
-
-  [morphdom]: https://github.com/patrick-steele-idem/morphdom
   [webpack]: https://webpack.js.org/
   [hbs-loader]: https://github.com/pcardune/handlebars-loader
   [browserify]: http://browserify.org/
+  [morphdom]: https://github.com/patrick-steele-idem/morphdom
   [hbsfy]: https://github.com/epeli/node-hbsfy

--- a/src/children/__tests__/children.spec.js
+++ b/src/children/__tests__/children.spec.js
@@ -2,7 +2,7 @@
 import 'core-js/shim';
 
 import { AssertionError } from 'assert';
-import { constant } from 'kefir';
+import { constant, never } from 'kefir';
 
 import chai, { expect } from 'chai';
 import sinon from 'sinon';
@@ -195,5 +195,24 @@ describe('children', () => {
 
             done();
         });
+    });
+
+
+    it('should use createSourceStream when available', () => {
+        let createSourceStream = sinon.spy(() => never());
+        let { factory, firstChild, instance, modifyChildProps, props$, preplug } = createFixture({ createSourceStream });
+        let sub = instance.observe();
+
+        expect(factory).to.have.callCount(0);
+        expect(createSourceStream).to.have.callCount(1);
+        expect(createSourceStream).to.have.been.calledWith(firstChild, props$);
+
+        expect(modifyChildProps).to.have.callCount(1);
+        expect(modifyChildProps).to.have.been.calledWith(props$, '1');
+
+        expect(preplug).to.have.callCount(1);
+        expect(preplug).to.have.been.calledWith(createSourceStream.getCall(0).returnValue);
+
+        sub.unsubscribe();
     });
 });

--- a/src/children/__tests__/util.js
+++ b/src/children/__tests__/util.js
@@ -1,7 +1,7 @@
 import R from 'ramda';
 import { pool } from 'kefir';
 import sinon from 'sinon';
-import { CONTAINER_ATTRIBUTE, KEY_ATTRIBUTE } from '../../constants';
+import { CONTAINER_ATTRIBUTE, KEY_ATTRIBUTE, $$internals } from '../../constants';
 import children from '../';
 
 /**
@@ -9,9 +9,10 @@ import children from '../';
  *
  * @returns {Fixture} Children test fixture.
  */
-export function createFixture() {
-    let child$ = pool();
-    let factory = sinon.spy(() => child$);
+export function createFixture({ child$ = pool(), factory = sinon.spy(() => child$), createSourceStream } = {}) {
+    if (createSourceStream) {
+        factory[$$internals] = { createSourceStream };
+    }
     let modifyChildProps = sinon.spy(R.identity);
     let preplug = sinon.spy(R.identity);
     let generator = children({ child: { factory, modifyChildProps, preplug } });

--- a/src/children/child.js
+++ b/src/children/child.js
@@ -6,15 +6,20 @@ import { KEY_ATTRIBUTE } from '../constants';
  * Create a new children stream instance from the given configuration, props$ stream & element.
  *
  * @param {string} container - Container key.
+ * @param {Function} createSourceStream - Function that generates a source stream.
  * @param {Function} factory - Instance factory function.
  * @param {Function} modifyChildProps - Creates a new props$ stream for the child.
  * @param {Function} preplug - Modify the child instance stream.
  * @param {string} key - @deprecated.
  * @returns {Kefir.Observable} Child instance.
  */
-export default function child({ container, factory, modifyChildProps = R.identity, preplug = R.identity, key }) {
+export default function child({ container, createSourceStream, factory, modifyChildProps = R.identity, preplug = R.identity, key }) {
     if (process.env.NODE_ENV !== 'production') {
-        assert.equal(typeof factory, 'function', `factory for ${container} should be a function`);
+        if (createSourceStream) {
+            assert.equal(typeof createSourceStream, 'function', `createSourceStream for ${container} should be a function`);
+        } else {
+            assert.equal(typeof factory, 'function', `factory for ${container} should be a function`);
+        }
         assert.equal(typeof modifyChildProps, 'function', `modifyChildProps for ${container} should be a function`);
         assert.equal(typeof preplug, 'function', `preplug for ${container} should be a function`);
 
@@ -57,7 +62,7 @@ Use the second parameter to modifyChildProps.`);
             );
         }
 
-        let instance$ = preplug(factory(element, childProps$), keyAttr);
+        let instance$ = preplug((createSourceStream || factory)(element, childProps$), keyAttr);
 
         if (useKey) {
             instance$ = instance$.map(action => Object.assign({}, action, {

--- a/src/children/index.js
+++ b/src/children/index.js
@@ -3,6 +3,7 @@ import R from 'ramda';
 import { constant, merge } from 'kefir';
 import child from './child';
 import { containerAttribute } from '../helpers';
+import { $$internals } from '../constants';
 import { getContainerNode, containerMatches, isAddedChildNode, isRemovedChildNode
 } from './util';
 import mutations$ from './mutations';
@@ -40,7 +41,13 @@ export default function children(factories) {
             definition = { factory: definition };
         }
 
-        factories[container] = child(R.merge({ container }, definition));
+        let createSourceStream = false;
+
+        if (definition.factory[$$internals]) {
+            ({ createSourceStream } = definition.factory[$$internals]);
+        }
+
+        factories[container] = child(Object.assign({ container, createSourceStream }, definition));
     }
 
     /**

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,4 +1,13 @@
 /**
+ * HTML attribute blackbox directive.
+ *
+ * For tagging a section of DOM to not update.
+ *
+ * @type {string}
+ */
+export const BLACKBOX_ATTRIBUTE = 'data-brk-blackbox';
+
+/**
  * HTML attribute container directive.
  *
  * @type {string}

--- a/src/helpers/blackboxAttribute.js
+++ b/src/helpers/blackboxAttribute.js
@@ -1,0 +1,5 @@
+import { BLACKBOX_ATTRIBUTE } from '../constants';
+
+export default function blackboxAttribute(container) {
+    return `${BLACKBOX_ATTRIBUTE}="${container}"`;
+}

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,3 +1,4 @@
+export { default as blackboxAttribute } from './blackboxAttribute';
 export { default as containerAttribute } from './containerAttribute';
 export { default as keyAttribute } from './keyAttribute';
 export { default as createFixture } from './createFixture';

--- a/src/render/index.js
+++ b/src/render/index.js
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { rafAction } from '../action';
-import { CONTAINER_ATTRIBUTE, KEY_ATTRIBUTE } from '../constants';
+import { BLACKBOX_ATTRIBUTE, CONTAINER_ATTRIBUTE, KEY_ATTRIBUTE } from '../constants';
 import R from 'ramda';
 import { stream } from 'kefir';
 import morphdom from 'morphdom';
@@ -47,75 +47,38 @@ export const renderFromHTML = R.curry((el, html) =>
 
         morphdom(el, html, {
             getNodeKey: function getNodeKey(el) {
-                if (el.hasAttribute && el.hasAttribute(CONTAINER_ATTRIBUTE) && el.hasAttribute(KEY_ATTRIBUTE)) {
-                    return `${el.getAttribute(CONTAINER_ATTRIBUTE)}::${el.getAttribute(KEY_ATTRIBUTE)}`;
+                let key = '';
+
+                // Ignore text nodes.
+                if (el.nodeType === 3) {
+                    return key;
                 }
 
-                return '';
-            },
-            onBeforeElUpdated: function blackboxContainer(fromEl, toEl) {
-                /**
-                 * Always update the top level element.
-                 *
-                 * We're making a few assumptions about the main element
-                 * and its relationship to the returned template:
-                 *
-                 * 1. The container type of the template already matches
-                 * the container type of the element. This should be matched
-                 * correctly when the element is mounted.
-                 *
-                 * 2. The key of the template already matches the key of
-                 * the element. If there is no key on either, then the
-                 * attribute is `null`. This should be matched correctly
-                 * using `modifyChildProps` to emit the props with the
-                 * correct key, assuming the use of the default render.
-                 *
-                 * These assumptions get verified below outside of production.
-                 */
-                if (fromEl === el) {
-                    if (process.env.NODE_ENV !== 'production') {
-                        assert.equal(
-                            el.getAttribute(CONTAINER_ATTRIBUTE),
-                            fromEl.getAttribute(CONTAINER_ATTRIBUTE),
-                            `The template ${CONTAINER_ATTRIBUTE} should match the root element ${CONTAINER_ATTRIBUTE}.`
-                        );
-                        assert.equal(
-                            el.getAttribute(KEY_ATTRIBUTE),
-                            fromEl.getAttribute(KEY_ATTRIBUTE),
-                            `The template ${KEY_ATTRIBUTE} should match the root element ${KEY_ATTRIBUTE}.`
-                        );
+                if (el.hasAttribute(CONTAINER_ATTRIBUTE)) {
+                    key = el.getAttribute(CONTAINER_ATTRIBUTE);
+
+                    if (el.getAttribute(KEY_ATTRIBUTE)) {
+                        key += `::${el.getAttribute(KEY_ATTRIBUTE)}`;
+                    }
+                }
+
+                if (el.hasAttribute(BLACKBOX_ATTRIBUTE)) {
+                    if (key) {
+                        key += '::';
                     }
 
+                    key += el.getAttribute(BLACKBOX_ATTRIBUTE);
+                }
+
+                return key;
+            },
+            onBeforeElUpdated: function blackboxContainer(fromEl) {
+                if (fromEl === el) {
                     return true;
                 }
 
                 // Update anything that isn't a container.
-                if (!fromEl.hasAttribute(CONTAINER_ATTRIBUTE)) {
-                    return true;
-                }
-
-                /**
-                 * If it is a container, we're going to do our own updating
-                 * and tell morphdom to move on.
-                 *
-                 * If the container has changed, swap element ourselves.
-                 * This is similar to how React handles it: If a subtree
-                 * is a different component, it just prunes and replaces,
-                 * since the subtree could be different in myriad different
-                 * ways and a full diff would be computationally
-                 * expensive. Additionally, this allows the MutationObserver
-                 * to continue to only worry about add/remove operations
-                 * instead of attribute mutations.
-                 */
-                if (fromEl.getAttribute(CONTAINER_ATTRIBUTE) !== toEl.getAttribute(CONTAINER_ATTRIBUTE) ||
-                    fromEl.getAttribute(KEY_ATTRIBUTE) !== toEl.getAttribute(KEY_ATTRIBUTE)
-                ) {
-                    fromEl.parentNode.replaceChild(toEl, fromEl);
-                }
-
-                // Tell morphdom to move on.
-                return false;
-
+                return !fromEl.hasAttribute(BLACKBOX_ATTRIBUTE);
             }
         });
 


### PR DESCRIPTION
We're not longer going to stream values into subsections of the DOM,
so much as just render the HTML for the whole page and update the
entire DOM as appropriate. The top-level component sets the context
for the HTML, so props get passed through the partial context rather
than having to do it in both the the partial context in the BE & the
stream context in the FE.

Add this to the release notes:

```markdown
* **BREAKING**: Rendering now happens from the root component down, rather than streaming individual values into individual components. This allows Handlebars to be the only context through which the developer has to understand the data flow into the DOM.
* **BREAKING**: Blackboxing is now handled explicitly through the use of `dat-brk-blackbox`. This can be used to carve out sections of the DOM from being updated, rather than the "container hack."```