### PR TITLE
Make mapActionTo Comply w/ Flux Standard Action

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "plugins": [
     "ramda",
+    "transform-object-rest-spread",
     "transform-object-assign"
   ],
   "env": {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,6 +4,7 @@ module.exports = {
         ecmaVersion: 6,
         sourceType: 'module',
         ecmaFeatures: {
+            experimentalObjectRestSpread: true,
             impliedStrict: true
         }
     },

--- a/docs/source/helpers.md
+++ b/docs/source/helpers.md
@@ -1,0 +1,52 @@
+---
+id: helpers
+title: Helpers
+---
+
+The helpers module isn't a separate module but a collection of functions to assist with common tasks in `brookjs`.
+
+## `mapActionTo` {Function}
+
+`mapActionTo` is a simple function designed to simplify the process of mapping child events to the parents events. It modifies the action's `type` and maintains the previous source in the Action's `meta`.
+
+```js
+import { mapActionTo } from 'brookjs';
+
+const child = {
+    type: 'CHILD',
+    payload: { value: true }
+};
+
+const parent = mapActionTo('CHILD', 'PARENT', child);
+
+assert(parent === {
+    type: 'PARENT',
+    payload: { value: true },
+    meta: { sources: ['CHILD'] }
+});
+```
+
+If the source action doesn't match, the action is returned:
+
+```js
+import { mapActionTo } from 'brookjs';
+
+const child = {
+    type: 'OTHER_CHILD',
+    payload: { value: true }
+};
+
+const parent = mapActionTo('CHILD', 'PARENT', child);
+
+assert(parent === child);
+```
+
+### Parameters
+
+* {string} source - Action type to modify.
+* {string} dest - Action type to map.
+* {Action} action - Action to modify.
+
+### Returns
+
+* {Action} Modified action if `type` matches, original action if it doesn't.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-plugin-istanbul": "^3.1.2",
     "babel-plugin-ramda": "^1.1.3",
     "babel-plugin-transform-object-assign": "^6.8.0",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.13.2",
     "babel-register": "^6.9.0",
     "chai": "^3.5.0",

--- a/src/helpers/__tests__/helpers.spec.js
+++ b/src/helpers/__tests__/helpers.spec.js
@@ -1,6 +1,7 @@
 /*eslint-env mocha */
-import { eventAttribute, containerAttribute, keyAttribute } from '../';
+import { eventAttribute, containerAttribute, keyAttribute, mapActionTo } from '../';
 import { expect } from 'chai';
+import sinon from 'sinon';
 
 describe('helpers', function() {
     describe('event', function() {
@@ -26,6 +27,65 @@ describe('helpers', function() {
     describe('key', () => {
         it('should return key attribute', () => {
             expect(keyAttribute('123')).to.equals('data-brk-key="123"');
+        });
+    });
+
+    describe('mapActionTo', () => {
+        before(() => {
+            sinon.stub(console, 'warn').callsFake(() => {});
+        });
+
+        it('should be curried', () => {
+            expect(mapActionTo('SOURCE')).to.be.a('function');
+            expect(mapActionTo('SOURCE', 'DEST')).to.be.a('function');
+        });
+
+        it('should leave unmatched action alone', () => {
+            const action = {
+                type: 'NOT_SOURCE',
+                payload: { test: true }
+            };
+
+            expect(mapActionTo('SOURCE', 'DEST', action)).to.equal(action);
+        });
+
+        it('should map source to dest with meta', () => {
+            const action = {
+                type: 'SOURCE',
+                payload: { test: true }
+            };
+
+            expect(mapActionTo('SOURCE', 'DEST', action)).to.eql({
+                type: 'DEST',
+                payload: { test: true },
+                meta: {
+                    sources: ['SOURCE']
+                },
+                source: 'SOURCE'
+            });
+        });
+
+        it('should update meta when mapping', () => {
+            const action = {
+                type: 'SOURCE',
+                payload: { test: true },
+                meta: {
+                    sources: ['PREV_SOURCE']
+                }
+            };
+
+            expect(mapActionTo('SOURCE', 'DEST', action)).to.eql({
+                type: 'DEST',
+                payload: { test: true },
+                meta: {
+                    sources: ['PREV_SOURCE', 'SOURCE']
+                },
+                source: 'SOURCE'
+            });
+        });
+
+        after(() => {
+            console.warn.restore();
         });
     });
 });

--- a/src/helpers/mapActionTo.js
+++ b/src/helpers/mapActionTo.js
@@ -1,10 +1,23 @@
 import R from 'ramda';
 
-export default R.curry(function mapActionTo(source, dest, { type, payload }) {
-    if (type === source) {
-        type = dest;
-        payload = Object.assign({}, payload, { source });
+export default R.curry(function mapActionTo(source, dest, action) {
+    if (action.type !== source) {
+        return action;
     }
 
-    return { type, payload };
+    const { meta = {}, ...rest } = action;
+
+    return {
+        ...rest,
+        type: dest,
+        meta: {
+            ...meta,
+            sources: (meta.sources || []).concat(source)
+        },
+        get source() {
+            console.warn('`source` is now located at `meta.sources`');
+
+            return source;
+        }
+    };
 });


### PR DESCRIPTION
Move the `source` information to `meta`.

Fixes #30.

* [x] Add docs for `mapActionTo`