### PR TITLE
Deprecate `component` in favor of `view`

### DIFF
--- a/src/domDelta/__tests__/domDelta.spec.js
+++ b/src/domDelta/__tests__/domDelta.spec.js
@@ -41,10 +41,10 @@ describe('domDelta', () => {
         });
     });
 
-    it('should emit an error if incorrect component', done => {
+    it('should emit an error if incorrect view', done => {
         const actions$ = never();
         const state$ = never();
-        const delta = domDelta({ el: document.body, component: false });
+        const delta = domDelta({ el: document.body, view: false });
 
         const delta$ = delta(actions$, state$);
 
@@ -65,7 +65,7 @@ describe('domDelta', () => {
     it('should emit an error if incorrect selectProps', done => {
         const actions$ = never();
         const state$ = never();
-        const delta = domDelta({ el: document.body, component: never, selectProps: false });
+        const delta = domDelta({ el: document.body, view: never, selectProps: false });
 
         const delta$ = delta(actions$, state$);
 

--- a/src/domDelta/index.js
+++ b/src/domDelta/index.js
@@ -10,7 +10,12 @@ const documentIsLoaded = () =>
         )
     );
 
-export default function domDelta({ el, component, selectProps }) {
+export default function domDelta({ el, component, view, selectProps }) {
+    if (component) {
+        console.warn('`component` in `domDelta` is deprecated. use `view`.');
+        view = component;
+    }
+
     let precheck$ = constant('Configuration correct');
 
     if (typeof el === 'function') {
@@ -21,7 +26,7 @@ export default function domDelta({ el, component, selectProps }) {
         precheck$ = constantError(new TypeError(`el of type ${typeof el} is not valid`));
     }
 
-    if (typeof component !== 'function') {
+    if (typeof view !== 'function') {
         precheck$ = constantError(new TypeError(`component of type ${typeof el} is not valid`));
     }
 
@@ -39,6 +44,6 @@ export default function domDelta({ el, component, selectProps }) {
             )
             .flatMap(R.always(el))
             .take(1).takeErrors(1)
-            .flatMap(el => component(el, selectProps(state$)));
+            .flatMap(el => view(el, selectProps(state$)));
     };
 }


### PR DESCRIPTION
Sorry to be annoying, but in reviewing the documentation, I felt this was
a more appropriate parameter name for this function.