### PR TITLE
Fix typo in code example markdown

### DIFF
--- a/docs/source/animating-a-component.md
+++ b/docs/source/animating-a-component.md
@@ -5,7 +5,7 @@ title: Animating a Component
 
 `brookjs` provides lifecycle hooks for managing the changes that can take place on a component. Enable those hooks by adding a data attribute to the element you want to animate in your component's HTML:
 
-```hbs
+```handlebars
 <div data-brk-container="parent">
     <ul>
         {{#each option}}


### PR DESCRIPTION
There was a typo in the GFM for a code block for Handlebars.