### PR TITLE
Add greenkeeper-lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,21 @@
-sudo: true
+sudo: false
 language: node_js
 
 node_js:
   - stable
 
-before_install:
-  # Repo for Yarn
-  - sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3
-  - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-  - sudo apt-get update -qq
-  - sudo apt-get install -y -qq yarn
-
 cache:
   directories:
   - $HOME/.yarn-cache
 
-install:
-  - yarn
+before_install:
+  - yarn global add greenkeeper-lockfile@1
+
+before_script:
+  - greenkeeper-lockfile-update
 
 script:
   - yarn test
+
+after_script:
+  - greenkeeper-lockfile-upload


### PR DESCRIPTION
Keeps the yarn.lock file up to date. Sticking with yarn for now
because I have unrelated issues with to sort out with npm@5, so I'm
still on npm@4.

Fixes #62.