### PR TITLE
Fix bug when MObs emits 3 actions for node

### DIFF
--- a/src/children/__tests__/util.spec.js
+++ b/src/children/__tests__/util.spec.js
@@ -1,0 +1,70 @@
+/* eslint-env mocha */
+import { expect } from 'chai';
+
+import { dedupeListOfMutationActions } from '../util';
+
+describe('children util', () => {
+    describe('dedupeListOfMutationRecords', () => {
+        it.skip('should remove add/remove/added list', () => {
+            const list = [
+                {
+                    'type': 'NODE_ADDED',
+                    'payload': {
+                        'target': {},
+                        'node': {
+                            'class': 'table',
+                            'data-brk-container': 'settingsAccounts'
+                        }
+                    }
+                },
+                {
+                    'type': 'NODE_REMOVED',
+                    'payload': {
+                        'target': {},
+                        'node': {}
+                    }
+                },
+                {
+                    'type': 'NODE_ADDED',
+                    'payload': {
+                        'target': {},
+                        'node': {
+                            'class': 'table',
+                            'data-brk-container': 'settingsAccounts'
+                        }
+                    }
+                },
+                {
+                    'type': 'NODE_REMOVED',
+                    'payload': {
+                        'target': {},
+                        'node': {
+                            'class': 'table',
+                            'data-brk-container': 'settingsAccounts'
+                        }
+                    }
+                }
+            ];
+
+            expect(dedupeListOfMutationActions(list)).to.eql([
+                {
+                    'type': 'NODE_ADDED',
+                    'payload': {
+                        'target': {},
+                        'node': {
+                            'class': 'table',
+                            'data-brk-container': 'settingsAccounts'
+                        }
+                    }
+                },
+                {
+                    'type': 'NODE_REMOVED',
+                    'payload': {
+                        'target': {},
+                        'node': {}
+                    }
+                }
+            ]);
+        });
+    });
+});


### PR DESCRIPTION
This fixes an odd bug I'm having in my app since switching to
diffhtml: sometimes, the MutationObserver emits 3 records for a
single node, an add, a remove, and an add. The current algorithm
was deduping too aggressively, eliminating all 3 of the records for
the node, depending on the order in which they arrived. This
resolves that issue by chunking up the list and cancelling out
matching cross-types, so we're only left with the single
appropriate action.

This may be some of the worst code I've ever written, but this is
a show-stopper, as the children aren't mounting nodes that are
added to the DOM and thus being rendered inert. I fully intend
to refactor this once I'm both able to reproduce a usable test
case for the utility function as well as reproduce it against an
actual MutationObserver. I'd _really_ like to find out what part of
the render process is actually doing this, but that's made more
complicated by the fact that I'm touching the DOM in between
renders. I have test cases that look at that, so I'm not sure what
the problem is just yet.

This could be solved by plugging the children into the diffhtml
middleware rather than using a MutationObserver, but it would
mean that userland would have to use our render tools in order
to make DOM changes, rather being able to do whatever they
want, with the MO watching for all of it. If the MO turns out to
be a bottleneck, then that's a good argument for switching and
providing decent/better tools for userland to do its own rendering.
That's pretty much what React does anyway, so it wouldn't be
entirely out of the ordinary, and `onMount` still provides a "drop
below the framework" out to do whatever you want. The only
restiction would be that you'd have to add subcomponents to the
DOM **only** through our render tools.

Really, at some point we're going to have to focus in on
performance, and plugging everything into the middleware could
improve that, rather than going through the browser/DOM directly,
so there are good and bad reasons for both. But this is at least a
short term hack that's self-contained enough to be resolved later.