### PR TITLE
Cleanup action dedupe algorithm

### DIFF
--- a/src/children/__tests__/children.spec.js
+++ b/src/children/__tests__/children.spec.js
@@ -197,7 +197,6 @@ describe('children', () => {
         });
     });
 
-
     it('should use createSourceStream when available', () => {
         const createSourceStream = sinon.spy(() => Kefir.never());
         const { factory, firstChild, instance, modifyChildProps, props$, preplug } = createFixture({ createSourceStream });


### PR DESCRIPTION
`groupWith` didn't work like I expected, only grouping adjacent
nodes. Using `groupBy` just groups them into keys. Because
there's only 2 possible keys, we can `R.values` and end up
with what we wanted.