### PR TITLE
Remove default export from package

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,3 @@ import { raf$ } from './rAF';
 export { Kefir, children, combineActionReducers, component, events, domDelta,
     observeDelta, animateAttribute, containerAttribute, eventAttribute,
     mapActionTo, render, raf$, renderFromHTML };
-
-export default { Kefir, children, combineActionReducers, component, events, domDelta,
-    observeDelta, containerAttribute, eventAttribute,
-    mapActionTo, render, raf$, renderFromHTML };


### PR DESCRIPTION
No reason to export in both places here. No one is going to
`const brookjs = requrire('brookjs').default` when you can
`require('brookjs')` to get the same thing.