### PR TITLE
Fix props migration on alternate code path

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,4 @@ The changelog can be found [here][changelog].
   [babel]: https://babeljs.io/
   [semver]: http://semver.org/
   [docs]: https://valtech-nyc.github.io/brookjs/
-  [changelog]: valtech-nyc.github.io/brookjs/changelog.html
+  [changelog]: https://valtech-nyc.github.io/brookjs/changelog.html

--- a/packages/brookjs-silt/src/__tests__/h.spec.js
+++ b/packages/brookjs-silt/src/__tests__/h.spec.js
@@ -171,14 +171,23 @@ describe('h', () => {
     });
 
     describe('ref', () => {
-        const WithRef = ({ refCallback }) => (
-            <p ref={refCallback}>Hello world</p>
+        const WithRef = ({ refCallback, text$ }) => (
+            <p ref={refCallback}>{text$}</p>
         );
 
         it('should call callback with reference', () => {
             const ref = sinon.spy();
 
-            mount(<WithRef refCallback={ref}>Hello world!</WithRef>);
+            mount(<WithRef refCallback={ref} text$={'Hello world'}/>);
+
+            expect(ref).to.have.callCount(1);
+            expect(ref.getCall(0).args[0].outerHTML).to.equal('<p>Hello world</p>');
+        });
+
+        it('should call callback with reference with embedded observable', () => {
+            const ref = sinon.spy();
+
+            mount(<WithRef refCallback={ref} text$={Kefir.constant('Hello world')}/>);
 
             expect(ref).to.have.callCount(1);
             expect(ref.getCall(0).args[0].outerHTML).to.equal('<p>Hello world</p>');

--- a/packages/brookjs-silt/src/h.js
+++ b/packages/brookjs-silt/src/h.js
@@ -87,15 +87,9 @@ const forEachInProps = (props, arg, fn) => {
 };
 
 const filterProps = (type, props) => {
-    const newProps = { [TYPE]: type };
-    for (const key in props) {
-        const prop = props[key];
-
-        if (PROP !== key) {
-            newProps[key] = prop;
-        }
-    }
-    return newProps;
+    // Throw away PROP, migrate ref.
+    const { [PROP]: _, [REF]: ref, ...rest } = props; // eslint-disable-line no-unused-vars
+    return { ...rest, [DD_REF]: ref, [TYPE]: type };
 };
 
 const incValues = self => {
@@ -348,9 +342,7 @@ const h = (type, props, ...children) => {
             props = filterProps(type, props);
             type = FromClass;
         } else if (props[PROP]) {
-            // Throw away PROP, migrate ref.
-            const { [PROP]: _, [REF]: ref, ...rest } = props; // eslint-disable-line no-unused-vars
-            props = { ...rest, [DD_REF]: ref };
+            props = filterProps(type, props);
         }
     }
     return createElement(type, props, ...children);


### PR DESCRIPTION
Use `filterProps` in both paths for consistency.