### PR TITLE
Allow passing `mapper` in first

### DIFF
--- a/flow-typed/npm/chai_v4.x.x.js
+++ b/flow-typed/npm/chai_v4.x.x.js
@@ -137,7 +137,7 @@ declare module "chai" {
     value: (val: string) => ExpectChain<T>,
 
     // chai-kefir
-    emit: (event: Array<Event>, callback: Function) => ExpectChain<T>,
+    emit: (event: Array<Event>, callback?: Function) => ExpectChain<T>,
     emitInTime: (events: Array<TimedEvent>, callback: Function) => ExpectChain<T>,
     emitEffectsInTime: (events: Array<TimedEvent>, callback: Function) => ExpectChain<T>
   };

--- a/packages/brookjs-silt/src/__tests__/loop.spec.js
+++ b/packages/brookjs-silt/src/__tests__/loop.spec.js
@@ -218,4 +218,20 @@ describe('loop', () => {
             })]);
         });
     });
+
+    it('should take map function', () => {
+        const a = send(prop(), [value({
+            loopable: {
+                order: ['a', 'b'],
+                dict: {
+                    a: { text: 'first box' },
+                    b: { text: 'second box' }
+                }
+            }
+        })]);
+
+        const dom$ = a.thru(loop(props => props.loopable, (child$, id) => (id: any)));
+
+        expect(dom$).to.emit([value(['a', 'b'], { current: true })]);
+    });
 });


### PR DESCRIPTION
This is often combined, so easier to just enable it in the `loop`.

Fixes #137.