### PR TITLE
Allow filenames to be dynamic

### DIFF
--- a/packages/brookjs-cli/src/selectors/build.js
+++ b/packages/brookjs-cli/src/selectors/build.js
@@ -64,9 +64,19 @@ const selectWebpackEntry = state => {
     return R.map(e => path.join(selectAppPath(state), e), entry);
 };
 
+const selectFilename = state => {
+    let filename = R.view(lWebpackOutputFilename, state);
+
+    if (typeof filename === 'function') {
+        filename = filename(state);
+    }
+
+    return filename;
+};
+
 const selectOutput = state => ({
     path: path.join(R.view(lEnvCwd, state), R.view(lWebpackOutputPath, state)),
-    filename: R.view(lWebpackOutputFilename, state)
+    filename: selectFilename(state)
 });
 
 export const selectWebpackConfig = state => state.webpack.modifier({


### PR DESCRIPTION
This allows the developer to e.g. modify the extensions depending on
whether or not it's in development or production.