### PR TITLE
Add fromReact wrapper helper

### DIFF
--- a/packages/brookjs-silt/src/fromReact.js
+++ b/packages/brookjs-silt/src/fromReact.js
@@ -1,0 +1,26 @@
+import ReactDOM from 'react-dom';
+import { Kefir, component } from 'brookjs';
+import h from './h';
+import Aggregator from './Aggregator';
+
+/**
+ * Convert React component to old-style brookjs component.
+ *
+ * @param  {React.Component|function} Component - React component to wrap.
+ * @returns{Component} brookjs component.
+ * @deprecated
+ */
+export default function withReact(Component) {
+    return component({
+        onMount: (el, stream$) => Kefir.stream(emitter => {
+            ReactDOM.render(
+                <Aggregator action$={action$ => action$.observe(emitter)}>
+                    <Component stream$={stream$} />
+                </Aggregator>,
+                el
+            );
+
+            return () => ReactDOM.unmountComponentAtNode(el);
+        })
+    });
+}

--- a/packages/brookjs-silt/src/index.js
+++ b/packages/brookjs-silt/src/index.js
@@ -1,10 +1,11 @@
 // @flow
 import Aggregator from './Aggregator';
 import Collector from './Collector';
+import fromReact from './fromReact';
 import h from './h';
 import loop from './loop';
 import view from './view';
 import withRef$ from './withRef$';
 
-export { Aggregator, Collector, h,
+export { Aggregator, Collector, h, fromReact,
     h as createElement, loop, view, withRef$ };


### PR DESCRIPTION
This allows you to use your React components into your old-style
brookjs components, migrating your leaf components to React in
a piecemeal fashion without needing to overhaul the entire app at once.

Like the old-style component, you'll need to continue to use
`data-brk-container` to point at the node where React should be mounted.
Additionally, you'll need to use `data-brk-blackbox` so brookjs doesn't
modify the node that React now controls. See this PR for an example:
https://github.com/intraxia/wp-gistpen/pull/237

Fixes #153.