### PR TITLE
Use create-react-ref in withRef$ HOC

### DIFF
--- a/packages/brookjs-silt/package.json
+++ b/packages/brookjs-silt/package.json
@@ -55,9 +55,10 @@
   "dependencies": {
     "brookjs": "^0.11.11",
     "create-react-context": "^0.2.1",
+    "create-react-ref": "^0.1.0",
     "kefir": "^3.8.1",
     "prop-types": "^15.6.0",
     "ramda": "^0.25.0",
-    "react": "^16.3.0"
+    "react": "^16.0.0"
   }
 }

--- a/packages/brookjs-silt/src/__tests__/Aggregator.spec.js
+++ b/packages/brookjs-silt/src/__tests__/Aggregator.spec.js
@@ -15,7 +15,7 @@ configure({ adapter: new Adapter() });
 use(plugin);
 use(sinonChai);
 
-describe.skip('Aggregator', () => {
+describe('Aggregator', () => {
     it('should provide aggregated$ as context', () => {
         const spy = sinon.spy(() => {});
         mount(

--- a/packages/brookjs-silt/src/__tests__/Collector.spec.js
+++ b/packages/brookjs-silt/src/__tests__/Collector.spec.js
@@ -13,7 +13,7 @@ const { plugin, value } = chaiPlugin({ Kefir });
 configure({ adapter: new Adapter() });
 use(plugin);
 
-describe.skip('Collector', () => {
+describe('Collector', () => {
     const onButtonClick = e$ => e$.map(() => ({ type: 'CLICK' }));
 
     const CollectedButton = ({ text, enabled, aggregated$ }) => (

--- a/packages/brookjs-silt/src/__tests__/withRef$.spec.js
+++ b/packages/brookjs-silt/src/__tests__/withRef$.spec.js
@@ -28,7 +28,7 @@ const Instance = ({ text, aggregated$ }) => (
     </Provider>
 );
 
-describe.skip('withRef$', () => {
+describe('withRef$', () => {
     it('should emit value from ref$', () => {
         const aggregated$ = Kefir.pool();
         const wrapper = mount(
@@ -37,6 +37,6 @@ describe.skip('withRef$', () => {
                 aggregated$={aggregated$} />
         );
 
-        expect(aggregated$).to.emit([value([wrapper.find('button'), { text: 'Click me!' }], { current: true })]);
+        expect(aggregated$).to.emit([value([wrapper.find('button').instance(), { text: 'Click me!' }], { current: true })]);
     });
 });

--- a/packages/brookjs-silt/src/withRef$.js
+++ b/packages/brookjs-silt/src/withRef$.js
@@ -1,4 +1,4 @@
-import { forwardRef } from 'react';
+import { createRef, forwardRef, getRef } from 'create-react-ref';
 import Kefir from 'kefir';
 import h from './h';
 import { Consumer } from './context';
@@ -8,19 +8,35 @@ const getDisplayName = Component =>
 
 export default function withRef$(c, callback) {
     const Component = forwardRef(c);
-    const WithRef = props => {
-        const ref$ = new Kefir.Property();
 
-        return (
-            <Consumer>
-                {aggregated$ => {
-                    aggregated$.plug(callback(ref$, props));
+    class WithRef extends Component {
+        constructor(props, context) {
+            super(props, context);
+            this.ref$ = new Kefir.Property();
+            this.ref = createRef();
+            this.el = null;
+        }
 
-                    return <Component {...props} ref={el => el && ref$._emitValue(el)} />;
-                }}
-            </Consumer>
-        );
-    };
+        componentDidMount() {
+            const el = getRef(this.ref);
+
+            if (el && this.el !== el) {
+                this.ref$._emitValue(el);
+                this.el = el;
+            }
+        }
+
+        render() {
+            return (
+                <Consumer>
+                    {aggregated$ => {
+                        aggregated$.plug(callback(this.ref$, this.props));
+                        return <Component {...this.props} ref={this.ref} />;
+                    }}
+                </Consumer>
+            );
+        }
+    }
 
     WithRef.displayName = `WithRef(${getDisplayName(Component)})`;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2165,6 +2165,12 @@ create-react-context@^0.2.1:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
+create-react-ref@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/create-react-ref/-/create-react-ref-0.1.0.tgz#0aa42aae4e66d8b164207ac8c468c35ce7bbd8eb"
+  dependencies:
+    fbjs "^0.8.16"
+
 cross-env@^5.0.1, cross-env@^5.0.5, cross-env@^5.1.1:
   version "5.1.4"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.4.tgz#f61c14291f7cc653bb86457002ea80a04699d022"
@@ -6571,9 +6577,9 @@ react-test-renderer@^16.0.0-0:
     prop-types "^15.6.0"
     react-is "^16.3.2"
 
-react@^16.3.0:
-  version "16.4.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.4.0.tgz#402c2db83335336fba1962c08b98c6272617d585"
+react@16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
This enables us to drop the required React version again and reenable
the other tests.

Fixes #182.