### PR TITLE
Deprecate brookjs#component and children

### DIFF
--- a/packages/brookjs/src/component/children/index.js
+++ b/packages/brookjs/src/component/children/index.js
@@ -13,6 +13,8 @@ import child from './child';
  */
 export default function children (factories) {
     if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.warn('brookjs#children has been deprecated. Please migrate to brookjs-silt (React-based components).');
         assert.equal(typeof factories, 'object', '`factories` should be an object');
 
         for (const container in factories) {

--- a/packages/brookjs/src/component/events/index.js
+++ b/packages/brookjs/src/component/events/index.js
@@ -95,9 +95,14 @@ const eventMatches = R.curry(function eventMatches(key, el, event) {
  * @returns {Function} Events stream generator function.
  */
 export default function events(config) {
-    for (const key in config) {
-        if (config.hasOwnProperty(key)) {
-            assert.equal(typeof config[key], 'function', `events[${key}] is not a function`);
+    if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.warn('brookjs#component has been deprecated. Please migrate to brookjs-silt (React-based components).');
+
+        for (const key in config) {
+            if (config.hasOwnProperty(key)) {
+                assert.equal(typeof config[key], 'function', `events[${key}] is not a function`);
+            }
         }
     }
 

--- a/packages/brookjs/src/component/index.js
+++ b/packages/brookjs/src/component/index.js
@@ -30,6 +30,9 @@ export function component({
     render = renderFactory(() => '')
 }) {
     if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.warn('brookjs#component has been deprecated. Please migrate to brookjs-silt (React-based components).');
+
         // Validate events function.
         assert.equal(typeof events, 'function', '`events` should be a function');
 

--- a/packages/brookjs/src/component/render/index.js
+++ b/packages/brookjs/src/component/render/index.js
@@ -37,6 +37,8 @@ export const renderFromHTML = R.curry((el, html) =>
  */
 export default function render(template, modifyEffect$$ = R.identity) {
     if (process.env.NODE_ENV !== 'production') {
+        // eslint-disable-next-line no-console
+        console.warn('brookjs#render has been deprecated. Please migrate to brookjs-silt (React-based components).');
         assert.equal(typeof template, 'function', '`template` should be a function');
         assert.equal(typeof modifyEffect$$, 'function', '`modifyEffect$$` should be a function');
     }


### PR DESCRIPTION
Note that `raf$` and `RAF` are _not_ deprecated.

Fixes #148.